### PR TITLE
Pwn2Play 2026 redesign + 26/27 committee handover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 public
 bin
+
+# Claude Code local worktrees / session state
+.claude/

--- a/P2P.html
+++ b/P2P.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Pwn2Play CTF - DMU Hackers Capture The Flag Competition</title>
-  <meta name="description" content="Pwn2Play: Core Incursion is DMU Hackers' flagship student CTF on 30 May 2026, bridging technical challenge practice with industry sponsor visibility.">
+  <meta name="description" content="Pwn2Play: Core Incursion — DMU Hackers' flagship student CTF on 30 May 2026. 55 challenges across 12 categories, 300+ competitors in 150+ teams, hybrid in Leicester and online.">
   <meta property="og:title" content="Pwn2Play CTF - DMU Hackers">
-  <meta property="og:description" content="A Jeopardy-style CTF for students to validate practical cyber skills and connect with industry sponsors.">
+  <meta property="og:description" content="55 challenges, 300+ student competitors, 150+ teams. DMU Hackers' flagship Jeopardy-style CTF on 30 May 2026, hybrid in Leicester and online.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://dmuhackers.com/P2P.html">
   <meta property="og:image" content="https://dmuhackers.com/img/site-content/logo/1200x630.png">
@@ -15,7 +15,7 @@
   <meta name="twitter:image" content="https://dmuhackers.com/img/site-content/logo/1200x628.png">
   <meta name="twitter:site" content="@dmuhackers">
   <meta name="twitter:title" content="Pwn2Play CTF - DMU Hackers">
-  <meta name="twitter:description" content="A Jeopardy-style CTF for students to validate practical cyber skills and connect with industry sponsors.">
+  <meta name="twitter:description" content="55 challenges, 300+ student competitors, 150+ teams. DMU Hackers' flagship Jeopardy-style CTF on 30 May 2026, hybrid in Leicester and online.">
   <link rel="canonical" href="https://dmuhackers.com/P2P.html">
   <link rel="icon" href="favicon.ico" type="image/x-icon">
   <link rel="apple-touch-icon" sizes="180x180" href="img/site-content/logo/180x180.png">
@@ -90,7 +90,9 @@
       <ul class="nav__links" id="navLinks">
         <li><a href="index.html" class="nav__link">Home</a></li>
         <li><a href="#p2p-hero" class="nav__link active" data-section="p2p-hero">Pwn2Play</a></li>
+        <li><a href="#event-pulse" class="nav__link" data-section="event-pulse">Pulse</a></li>
         <li><a href="#categories" class="nav__link" data-section="categories">Categories</a></li>
+        <li><a href="#challenge-spread" class="nav__link" data-section="challenge-spread">Breakdown</a></li>
         <li><a href="#prizes" class="nav__link" data-section="prizes">Prizes</a></li>
         <li><a href="#rules" class="nav__link" data-section="rules">Rules</a></li>
         <li><a href="#sponsors" class="nav__link" data-section="sponsors">Sponsors</a></li>
@@ -198,13 +200,46 @@
     </div>
   </section>
 
+  <!-- Live Event Pulse -->
+  <section id="event-pulse" class="section section--alt">
+    <div class="container">
+      <div class="section__header">
+        <span class="section__tag" data-p2p-pulse-tag>Live Pulse</span>
+        <h2 class="section__title" data-p2p-pulse-title>Core Incursion at a Glance</h2>
+        <p class="section__subtitle" data-p2p-pulse-subtitle>Live as the event unfolds &mdash; updated by the committee on the day.</p>
+      </div>
+      <div class="p2p-pulse" data-p2p-pulse>
+        <article class="p2p-pulse__tile" data-pulse-key="signups">
+          <span class="p2p-pulse__label">Signups</span>
+          <strong class="p2p-pulse__value">300+</strong>
+          <span class="p2p-pulse__suffix">members on Biterra</span>
+        </article>
+        <article class="p2p-pulse__tile" data-pulse-key="teams">
+          <span class="p2p-pulse__label">Teams</span>
+          <strong class="p2p-pulse__value">150+</strong>
+          <span class="p2p-pulse__suffix">registered</span>
+        </article>
+        <article class="p2p-pulse__tile" data-pulse-key="challenges">
+          <span class="p2p-pulse__label">Challenges</span>
+          <strong class="p2p-pulse__value">55</strong>
+          <span class="p2p-pulse__suffix">across 12 categories</span>
+        </article>
+        <article class="p2p-pulse__tile is-pending" data-pulse-key="flags">
+          <span class="p2p-pulse__label">Flags Pwned</span>
+          <strong class="p2p-pulse__value">&mdash;</strong>
+          <span class="p2p-pulse__suffix">Live on 30 May</span>
+        </article>
+      </div>
+    </div>
+  </section>
+
   <!-- Challenge Categories -->
   <section id="categories" class="section">
     <div class="container">
       <div class="section__header">
-        <span class="section__tag">12 Categories, 50 Challenges</span>
+        <span class="section__tag">12 Categories, 55 Challenges</span>
         <h2 class="section__title">Challenge Categories</h2>
-        <p class="section__subtitle">A broad challenge set weighted toward web exploitation, with room for reversing, forensics, OSINT, scripting, crypto and fundamentals.</p>
+        <p class="section__subtitle">A broad 2026 challenge set weighted toward web exploitation, with room for reversing, forensics, OSINT, scripting, crypto and fundamentals.</p>
       </div>
       <div class="cards cards--four p2p-cat-cards" data-p2p-categories>
         <div class="card p2p-cat-card">
@@ -218,7 +253,7 @@
         <div class="card p2p-cat-card">
           <div class="p2p-cat-card__top">
             <div class="card__icon"><i class="fas fa-microchip"></i></div>
-            <span class="p2p-cat-card__count">7</span>
+            <span class="p2p-cat-card__count">5</span>
           </div>
           <h3 class="card__title">Reverse Engineering</h3>
           <p class="card__text">Disassemble, decompile and decode binaries to uncover hidden logic.</p>
@@ -226,7 +261,7 @@
         <div class="card p2p-cat-card">
           <div class="p2p-cat-card__top">
             <div class="card__icon"><i class="fas fa-puzzle-piece"></i></div>
-            <span class="p2p-cat-card__count">7</span>
+            <span class="p2p-cat-card__count">8</span>
           </div>
           <h3 class="card__title">Miscellaneous</h3>
           <p class="card__text">Unexpected formats, strange clues and challenge ideas that refuse one label.</p>
@@ -242,7 +277,7 @@
         <div class="card p2p-cat-card">
           <div class="p2p-cat-card__top">
             <div class="card__icon"><i class="fas fa-magnifying-glass"></i></div>
-            <span class="p2p-cat-card__count">4</span>
+            <span class="p2p-cat-card__count">5</span>
           </div>
           <h3 class="card__title">OSINT</h3>
           <p class="card__text">Track down answers through public records, digital footprints and careful research.</p>
@@ -258,7 +293,7 @@
         <div class="card p2p-cat-card">
           <div class="p2p-cat-card__top">
             <div class="card__icon"><i class="fas fa-lock"></i></div>
-            <span class="p2p-cat-card__count">3</span>
+            <span class="p2p-cat-card__count">4</span>
           </div>
           <h3 class="card__title">Cryptography</h3>
           <p class="card__text">Break ciphers, exploit weak implementations and reason about flawed secrecy.</p>
@@ -266,7 +301,7 @@
         <div class="card p2p-cat-card">
           <div class="p2p-cat-card__top">
             <div class="card__icon"><i class="fab fa-linux"></i></div>
-            <span class="p2p-cat-card__count">2</span>
+            <span class="p2p-cat-card__count">1</span>
           </div>
           <h3 class="card__title">Linux</h3>
           <p class="card__text">Navigate shells, permissions, processes and system clues like an operator.</p>
@@ -274,7 +309,7 @@
         <div class="card p2p-cat-card">
           <div class="p2p-cat-card__top">
             <div class="card__icon"><i class="fas fa-terminal"></i></div>
-            <span class="p2p-cat-card__count">1</span>
+            <span class="p2p-cat-card__count">3</span>
           </div>
           <h3 class="card__title">Binary Exploitation</h3>
           <p class="card__text">Break compiled targets with memory corruption, control flow and exploit craft.</p>
@@ -282,7 +317,7 @@
         <div class="card p2p-cat-card">
           <div class="p2p-cat-card__top">
             <div class="card__icon"><i class="fas fa-skull-crossbones"></i></div>
-            <span class="p2p-cat-card__count">1</span>
+            <span class="p2p-cat-card__count">2</span>
           </div>
           <h3 class="card__title">Full-Pwn</h3>
           <p class="card__text">Chain attack paths from initial access to deeper compromise.</p>
@@ -307,8 +342,73 @@
     </div>
   </section>
 
+  <!-- Challenge Spread -->
+  <section id="challenge-spread" class="section section--alt">
+    <div class="container">
+      <div class="section__header">
+        <span class="section__tag">2026 Spread</span>
+        <h2 class="section__title">Challenge Breakdown</h2>
+        <p class="section__subtitle">55 challenges across categories and difficulties.</p>
+      </div>
+      <div class="p2p-breakdown" data-p2p-breakdown>
+        <article class="p2p-breakdown-card">
+          <div class="p2p-breakdown-card__visual">
+            <div class="p2p-breakdown-chart" style="background: conic-gradient(#c8102e 0% 28.30%, #00e4ff 28.30% 43.40%, #f4c95d 43.40% 52.83%, #34d399 52.83% 62.26%, #8b5cf6 62.26% 71.70%, #f97316 71.70% 79.25%, #f43f5e 79.25% 84.91%, #14b8a6 84.91% 90.57%, #e879f9 90.57% 94.34%, #a3e635 94.34% 96.23%, #38bdf8 96.23% 98.11%, #94a3b8 98.11% 100%)" role="img" aria-label="Challenge Categories pie chart for 55 challenges">
+              <div class="p2p-breakdown-chart__centre">
+                <strong>55</strong>
+                <span>challenges</span>
+              </div>
+            </div>
+          </div>
+          <div class="p2p-breakdown-card__body">
+            <span class="p2p-breakdown-card__eyebrow">Categories</span>
+            <h3 class="p2p-breakdown-card__title">Challenge Categories</h3>
+            <p class="p2p-breakdown-card__text">The final category mix for Pwn2Play: Core Incursion 2026.</p>
+            <ul class="p2p-breakdown-list">
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#c8102e"></span>Web Exploitation</span><span class="p2p-breakdown-list__value">15 / 28%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#00e4ff"></span>Miscellaneous</span><span class="p2p-breakdown-list__value">8 / 15%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#f4c95d"></span>Forensics</span><span class="p2p-breakdown-list__value">5 / 9%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#34d399"></span>OSINT</span><span class="p2p-breakdown-list__value">5 / 9%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#8b5cf6"></span>Reverse Engineering</span><span class="p2p-breakdown-list__value">5 / 9%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#f97316"></span>Cryptography</span><span class="p2p-breakdown-list__value">4 / 8%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#f43f5e"></span>Binary Exploitation</span><span class="p2p-breakdown-list__value">3 / 6%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#14b8a6"></span>Scripting</span><span class="p2p-breakdown-list__value">3 / 6%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#e879f9"></span>Full-Pwn</span><span class="p2p-breakdown-list__value">2 / 4%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#a3e635"></span>Code</span><span class="p2p-breakdown-list__value">1 / 2%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#38bdf8"></span>Intro</span><span class="p2p-breakdown-list__value">1 / 2%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#94a3b8"></span>Linux</span><span class="p2p-breakdown-list__value">1 / 2%</span></li>
+            </ul>
+          </div>
+        </article>
+        <article class="p2p-breakdown-card">
+          <div class="p2p-breakdown-card__visual">
+            <div class="p2p-breakdown-chart" style="background: conic-gradient(#34d399 0% 45.28%, #00e4ff 45.28% 73.58%, #f4c95d 73.58% 84.91%, #8b5cf6 84.91% 92.45%, #c8102e 92.45% 98.11%, #71717a 98.11% 100%)" role="img" aria-label="Challenge Difficulties pie chart for 55 challenges">
+              <div class="p2p-breakdown-chart__centre">
+                <strong>55</strong>
+                <span>challenges</span>
+              </div>
+            </div>
+          </div>
+          <div class="p2p-breakdown-card__body">
+            <span class="p2p-breakdown-card__eyebrow">Difficulty</span>
+            <h3 class="p2p-breakdown-card__title">Challenge Difficulties</h3>
+            <p class="p2p-breakdown-card__text">Difficulty labels from the final 2026 challenge set.</p>
+            <ul class="p2p-breakdown-list">
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#34d399"></span>Easy</span><span class="p2p-breakdown-list__value">24 / 45%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#00e4ff"></span>Medium</span><span class="p2p-breakdown-list__value">15 / 28%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#f4c95d"></span>Hard</span><span class="p2p-breakdown-list__value">6 / 11%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#8b5cf6"></span>Trivial</span><span class="p2p-breakdown-list__value">4 / 8%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#c8102e"></span>Extra Hard</span><span class="p2p-breakdown-list__value">3 / 6%</span></li>
+              <li><span class="p2p-breakdown-list__label"><span class="p2p-breakdown-list__swatch" style="background:#71717a"></span>Unspecified</span><span class="p2p-breakdown-list__value">1 / 2%</span></li>
+            </ul>
+          </div>
+        </article>
+      </div>
+    </div>
+  </section>
+
   <!-- Key Info -->
-  <section id="key-info" class="section section--alt">
+  <section id="key-info" class="section">
     <div class="container">
       <div class="section__header">
         <span class="section__tag">Important</span>

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Update:
 - `p2p.event.end`
 - `p2p.lastUpdated`
 - `p2p.categories`
+- `p2p.difficultyBreakdown`
+- `p2p.pulse`
 - `p2p.prizes`
 - `p2p.rules`
 - `p2p.schedule`

--- a/committee.html
+++ b/committee.html
@@ -102,7 +102,7 @@
               <div class="member member--sm">
                 <div class="member__img member__img--placeholder member__img--mini"><i class="fas fa-coins"></i></div>
                 <div class="member--sm__info">
-                  <span class="member__name">Jade Mensah</span>
+                  <span class="member__name">Amara Gouldbourne-Beckford</span>
                   <span class="member__role">Treasurer</span>
                 </div>
               </div>
@@ -114,9 +114,9 @@
                 </div>
               </div>
               <div class="member member--sm">
-                <div class="member__img member__img--placeholder member__img--mini"><i class="fas fa-flag"></i></div>
+                <div class="member__img member__img--placeholder member__img--mini"><i class="fas fa-user-plus"></i></div>
                 <div class="member--sm__info">
-                  <span class="member__name">Amara Gouldbourne-Beckford</span>
+                  <span class="member__name">Vacant</span>
                   <span class="member__role">CTF Officer</span>
                 </div>
               </div>

--- a/css/P2P.css
+++ b/css/P2P.css
@@ -658,6 +658,237 @@
   margin-top: auto;
 }
 
+/* ---------- Live Event Pulse ---------- */
+.p2p-pulse {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+.p2p-pulse__tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 26px 24px;
+  border: 1px solid rgba(255,255,255,.07);
+  border-radius: 8px;
+  background:
+    linear-gradient(145deg, rgba(255,255,255,.05), transparent 42%),
+    rgba(20,20,24,.72);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.035);
+  overflow: hidden;
+}
+
+.p2p-pulse__tile::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+  opacity: .55;
+}
+
+.p2p-pulse__label {
+  color: var(--accent);
+  font-family: var(--font-display);
+  font-size: .68rem;
+  font-weight: 700;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+
+.p2p-pulse__value {
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4.4vw, 2.8rem);
+  line-height: 1;
+}
+
+.p2p-pulse__suffix {
+  color: var(--text-muted);
+  font-size: .82rem;
+  line-height: 1.4;
+}
+
+.p2p-pulse__tile.is-pending .p2p-pulse__value {
+  color: var(--text-muted);
+}
+
+.p2p-pulse__tile.is-pending .p2p-pulse__label {
+  position: relative;
+  padding-left: 16px;
+}
+
+.p2p-pulse__tile.is-pending .p2p-pulse__label::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  transform: translateY(-50%);
+  box-shadow: 0 0 10px var(--accent);
+  animation: p2p-pulse-dot 1.8s ease-in-out infinite;
+}
+
+@keyframes p2p-pulse-dot {
+  0%, 100% { opacity: .35; transform: translateY(-50%) scale(.9); }
+  50%      { opacity: 1;   transform: translateY(-50%) scale(1.15); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .p2p-pulse__tile.is-pending .p2p-pulse__label::before {
+    animation: none;
+  }
+}
+
+/* ---------- Challenge Breakdown ---------- */
+.p2p-breakdown {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+.p2p-breakdown-card {
+  display: grid;
+  grid-template-columns: minmax(180px, .48fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: center;
+  min-height: 100%;
+  padding: 28px;
+  border: 1px solid rgba(255,255,255,.07);
+  border-radius: 8px;
+  background:
+    linear-gradient(145deg, rgba(255,255,255,.05), transparent 42%),
+    rgba(20,20,24,.72);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.035);
+}
+
+.p2p-breakdown-card__visual {
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+}
+
+.p2p-breakdown-chart {
+  position: relative;
+  width: min(220px, 100%);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 1px rgba(255,255,255,.08),
+    0 20px 45px rgba(0,0,0,.3),
+    inset 0 0 28px rgba(0,0,0,.28);
+}
+
+.p2p-breakdown-chart__centre {
+  position: absolute;
+  inset: 22%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 50%;
+  background: rgba(10,10,14,.88);
+  box-shadow: inset 0 0 20px rgba(0,0,0,.45);
+  text-align: center;
+}
+
+.p2p-breakdown-chart__centre strong {
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size: clamp(1.75rem, 4vw, 2.4rem);
+  line-height: 1;
+}
+
+.p2p-breakdown-chart__centre span {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: .62rem;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.p2p-breakdown-card__body {
+  min-width: 0;
+}
+
+.p2p-breakdown-card__eyebrow {
+  display: inline-block;
+  margin-bottom: 8px;
+  color: var(--accent);
+  font-family: var(--font-display);
+  font-size: .72rem;
+  font-weight: 700;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+
+.p2p-breakdown-card__title {
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size: 1.18rem;
+  margin-bottom: 8px;
+}
+
+.p2p-breakdown-card__text {
+  color: var(--text-muted);
+  font-size: .9rem;
+  line-height: 1.6;
+  margin-bottom: 18px;
+}
+
+.p2p-breakdown-list {
+  display: grid;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.p2p-breakdown-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--text);
+  font-size: .82rem;
+  line-height: 1.3;
+}
+
+.p2p-breakdown-list__label {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.p2p-breakdown-list__swatch {
+  flex: 0 0 auto;
+  width: 10px;
+  height: 10px;
+  margin-right: 8px;
+  border-radius: 50%;
+  box-shadow: 0 0 14px currentColor;
+}
+
+.p2p-breakdown-list__value {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-family: var(--font-display);
+  font-size: .74rem;
+  white-space: nowrap;
+}
+
 /* ---------- Shared action rows ---------- */
 .calendar-actions {
   display: flex;
@@ -1576,9 +1807,26 @@
 
 /* ---------- Responsive ---------- */
 @media (max-width: 768px) {
+  .p2p-breakdown,
+  .p2p-breakdown-card,
   .scoreboard-tracks,
   .prizes-showcase__intro,
   .prize-podium {
+    grid-template-columns: 1fr;
+  }
+
+  .p2p-pulse {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+  }
+
+  .p2p-breakdown-card {
+    padding: 24px 20px;
+  }
+}
+
+@media (max-width: 480px) {
+  .p2p-pulse {
     grid-template-columns: 1fr;
   }
 

--- a/css/theme-toggle.css
+++ b/css/theme-toggle.css
@@ -447,6 +447,48 @@ html.light .p2p-luma iframe {
   box-shadow: 0 14px 34px rgba(0,0,0,.08);
 }
 
+/* P2P live event pulse */
+html.light .p2p-pulse__tile {
+  background:
+    linear-gradient(145deg, rgba(200,16,46,.035), transparent 42%),
+    rgba(255,255,255,.82);
+  border-color: rgba(0,0,0,.08);
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.72),
+    0 12px 28px rgba(0,0,0,.06);
+}
+html.light .p2p-pulse__value {
+  color: var(--text);
+}
+html.light .p2p-pulse__suffix {
+  color: rgba(0,0,0,.55);
+}
+html.light .p2p-pulse__tile.is-pending .p2p-pulse__value {
+  color: rgba(0,0,0,.45);
+}
+
+/* P2P challenge breakdown */
+html.light .p2p-breakdown-card {
+  background:
+    linear-gradient(145deg, rgba(200,16,46,.035), transparent 42%),
+    rgba(255,255,255,.82);
+  border-color: rgba(0,0,0,.08);
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.72),
+    0 12px 28px rgba(0,0,0,.06);
+}
+html.light .p2p-breakdown-chart {
+  box-shadow:
+    0 0 0 1px rgba(0,0,0,.08),
+    0 18px 36px rgba(0,0,0,.1),
+    inset 0 0 20px rgba(0,0,0,.08);
+}
+html.light .p2p-breakdown-chart__centre {
+  background: rgba(255,255,255,.9);
+  border-color: rgba(0,0,0,.08);
+  box-shadow: inset 0 0 18px rgba(0,0,0,.055);
+}
+
 /* P2P prize podium */
 html.light .prizes-showcase__intro {
   border-top-color: rgba(0,0,0,.08);

--- a/data/site-content.js
+++ b/data/site-content.js
@@ -32,7 +32,9 @@ window.DMU_SITE_CONTENT = {
       "P2P.html": [
         { text: "Home", href: "index.html" },
         { text: "Pwn2Play", href: "#p2p-hero", section: "p2p-hero", active: true },
+        { text: "Pulse", href: "#event-pulse", section: "event-pulse" },
         { text: "Categories", href: "#categories", section: "categories" },
+        { text: "Breakdown", href: "#challenge-spread", section: "challenge-spread" },
         { text: "Prizes", href: "#prizes", section: "prizes" },
         { text: "Rules", href: "#rules", section: "rules" },
         { text: "Sponsors", href: "#sponsors", section: "sponsors" }
@@ -87,21 +89,21 @@ window.DMU_SITE_CONTENT = {
     }
   },
   committee: {
-    currentYear: "2025/26",
-    currentTag: "25/26 Committee",
+    currentYear: "2026/27",
+    currentTag: "26/27 Committee",
     currentMembers: [
-      {
-        name: "Adam",
-        fullName: "Adam Welbourne",
-        role: "Chairman",
-        icon: "fas fa-user-secret"
-      },
       {
         name: "Josh",
         fullName: "Josh Lloyd",
-        role: "Secretary",
+        role: "Chairman",
         icon: "fas fa-terminal",
         linkedin: "https://www.linkedin.com/in/josh-lloyd-227583366/"
+      },
+      {
+        name: "Nikita",
+        fullName: "Nikita Borodins",
+        role: "Secretary",
+        icon: "fas fa-keyboard"
       },
       {
         name: "Amara",
@@ -111,25 +113,23 @@ window.DMU_SITE_CONTENT = {
         linkedin: "https://www.linkedin.com/in/amara-g-98ab2a270/"
       },
       {
-        name: "Abbey",
-        fullName: "Abbey Rhodes",
+        name: "Deniz",
+        fullName: "Deniz Turgut",
         role: "Wellbeing Officer",
-        icon: "fas fa-shield-halved",
-        linkedin: "https://www.linkedin.com/in/abigailvr/"
+        icon: "fas fa-heart-pulse"
       },
       {
-        name: "Charlie",
-        fullName: "Charlie Burrows",
+        name: "Vacant",
+        fullName: "Vacant",
         role: "CTF Officer",
-        icon: "fas fa-flag",
-        linkedin: "https://www.linkedin.com/in/charlie-burrows-07108a336"
+        icon: "fas fa-user-plus",
+        vacant: true
       },
       {
-        name: "Ethan",
-        fullName: "Ethan Bauer",
+        name: "Ashley",
+        fullName: "Ashley Ray",
         role: "CTF Mentor",
-        icon: "fas fa-chalkboard-user",
-        linkedin: "https://www.linkedin.com/in/ethan-bauer-842124368/"
+        icon: "fas fa-graduation-cap"
       }
     ],
     timeline: [
@@ -139,9 +139,9 @@ window.DMU_SITE_CONTENT = {
         chair: { name: "Josh Lloyd", role: "Chairman", icon: "fas fa-terminal" },
         roles: [
           { name: "Nikita Borodins", role: "Secretary", icon: "fas fa-keyboard" },
-          { name: "Jade Mensah", role: "Treasurer", icon: "fas fa-coins" },
+          { name: "Amara Gouldbourne-Beckford", role: "Treasurer", icon: "fas fa-coins" },
           { name: "Deniz Turgut", role: "Wellbeing Officer", icon: "fas fa-heart-pulse" },
-          { name: "Amara Gouldbourne-Beckford", role: "CTF Officer", icon: "fas fa-flag" },
+          { name: "Vacant", role: "CTF Officer", icon: "fas fa-user-plus", vacant: true },
           { name: "Ashley Ray", role: "CTF Mentor", icon: "fas fa-graduation-cap" }
         ]
       },
@@ -270,18 +270,36 @@ window.DMU_SITE_CONTENT = {
     },
     categories: [
       { title: "Web Exploitation", count: 15, icon: "fas fa-globe", text: "SQL injection, XSS, SSRF, authentication bypasses and web logic flaws." },
-      { title: "Reverse Engineering", count: 7, icon: "fas fa-microchip", text: "Disassemble, decompile and decode binaries to uncover hidden logic." },
-      { title: "Miscellaneous", count: 7, icon: "fas fa-puzzle-piece", text: "Unexpected formats, strange clues and challenge ideas that refuse one label." },
+      { title: "Miscellaneous", count: 8, icon: "fas fa-puzzle-piece", text: "Unexpected formats, strange clues and challenge ideas that refuse one label." },
       { title: "Forensics", count: 5, icon: "fas fa-fingerprint", text: "Recover evidence from captures, filesystems, memory, logs and hidden artefacts." },
-      { title: "OSINT", count: 4, icon: "fas fa-magnifying-glass", text: "Track down answers through public records, digital footprints and careful research." },
+      { title: "OSINT", count: 5, icon: "fas fa-magnifying-glass", text: "Track down answers through public records, digital footprints and careful research." },
+      { title: "Reverse Engineering", count: 5, icon: "fas fa-microchip", text: "Disassemble, decompile and decode binaries to uncover hidden logic." },
+      { title: "Cryptography", count: 4, icon: "fas fa-lock", text: "Break ciphers, exploit weak implementations and reason about flawed secrecy." },
+      { title: "Binary Exploitation", count: 3, icon: "fas fa-terminal", text: "Break compiled targets with memory corruption, control flow and exploit craft." },
       { title: "Scripting", count: 3, icon: "fas fa-scroll", text: "Automate parsing, brute force paths and transform data under time pressure." },
-      { title: "Cryptography", count: 3, icon: "fas fa-lock", text: "Break ciphers, exploit weak implementations and reason about flawed secrecy." },
-      { title: "Linux", count: 2, icon: "fab fa-linux", text: "Navigate shells, permissions, processes and system clues like an operator." },
-      { title: "Binary Exploitation", count: 1, icon: "fas fa-terminal", text: "Break compiled targets with memory corruption, control flow and exploit craft." },
-      { title: "Full-Pwn", count: 1, icon: "fas fa-skull-crossbones", text: "Chain attack paths from initial access to deeper compromise." },
+      { title: "Full-Pwn", count: 4, icon: "fas fa-skull-crossbones", text: "Chain attack paths from initial access to deeper compromise." },
       { title: "Code", count: 1, icon: "fas fa-code", text: "Solve a focused programming problem with clean logic and fast execution." },
-      { title: "Intro", count: 1, icon: "fas fa-flag-checkered", text: "A first flag to get teams settled into the platform and event flow." }
+      { title: "Intro", count: 1, icon: "fas fa-flag-checkered", text: "A first flag to get teams settled into the platform and event flow." },
+      { title: "Linux", count: 1, icon: "fab fa-linux", text: "Navigate shells, permissions, processes and system clues like an operator." }
     ],
+    difficultyBreakdown: [
+      { title: "Easy", count: 25, color: "#34d399" },
+      { title: "Medium", count: 15, color: "#00e4ff" },
+      { title: "Hard", count: 8, color: "#f4c95d" },
+      { title: "Trivial", count: 4, color: "#8b5cf6" },
+      { title: "Extra Hard", count: 3, color: "#c8102e" }
+    ],
+    pulse: {
+      tag: "Live Pulse",
+      title: "Core Incursion at a Glance",
+      subtitle: "Live as the event unfolds — updated by the committee on the day.",
+      stats: [
+        { key: "signups", label: "Signups", value: "300+", suffix: "members on Biterra" },
+        { key: "teams", label: "Teams", value: "150+", suffix: "registered" },
+        { key: "challenges", label: "Challenges", value: "55", suffix: "across 12 categories" },
+        { key: "flags", label: "Flags Pwned", value: "—", suffix: "Live on 30 May" }
+      ]
+    },
     prizes: {
       tag: "Rewards",
       title: "In-Person Prizes",

--- a/index.html
+++ b/index.html
@@ -351,7 +351,7 @@
           <h2 class="section__title">Pwn2Play</h2>
           <p>Our flagship CTF competition. Test your skills against challenges in web exploitation, cryptography, reverse engineering and more. Open to everyone. Form a team of up to 6 and compete.</p>
           <div class="p2p-split__stats">
-            <div class="stat"><span class="stat__number" data-count="8">0</span><span class="stat__label">Categories</span></div>
+            <div class="stat"><span class="stat__number" data-count="12">0</span><span class="stat__label">Categories</span></div>
             <div class="stat"><span class="stat__number" data-count="2">0</span><span class="stat__label">Events</span></div>
           </div>
           <a href="P2P.html#register" class="btn btn--primary"><i class="fas fa-ticket"></i> Register for Pwn2Play</a>
@@ -398,28 +398,28 @@
   <section id="committee" class="section section--alt">
     <div class="container">
       <div class="section__header">
-        <span class="section__tag">25/26 Committee</span>
+        <span class="section__tag">26/27 Committee</span>
         <h2 class="section__title">The Team</h2>
         <p class="section__subtitle">The people keeping the lights on (and the shells popping).</p>
       </div>
       <div class="committee-grid" data-committee-current>
         <div class="member">
           <div class="member__img member__img--placeholder">
-            <i class="fas fa-user-secret"></i>
-          </div>
-          <h4 class="member__name">Adam</h4>
-          <p class="member__role">Chairman</p>
-
-          <span class="member__social member__social--disabled" aria-label="LinkedIn coming soon"><i class="fab fa-linkedin-in"></i></span>
-        </div>
-        <div class="member">
-          <div class="member__img member__img--placeholder">
             <i class="fas fa-terminal"></i>
           </div>
           <h4 class="member__name">Josh</h4>
-          <p class="member__role">Secretary</p>
+          <p class="member__role">Chairman</p>
 
           <a href="https://www.linkedin.com/in/josh-lloyd-227583366/" class="member__social" target="_blank" rel="noopener noreferrer" aria-label="Josh's LinkedIn profile"><i class="fab fa-linkedin-in"></i></a>
+        </div>
+        <div class="member">
+          <div class="member__img member__img--placeholder">
+            <i class="fas fa-keyboard"></i>
+          </div>
+          <h4 class="member__name">Nikita</h4>
+          <p class="member__role">Secretary</p>
+
+          <span class="member__social member__social--disabled" aria-label="LinkedIn coming soon"><i class="fab fa-linkedin-in"></i></span>
         </div>
         <div class="member">
           <div class="member__img member__img--placeholder">
@@ -432,30 +432,30 @@
         </div>
         <div class="member">
           <div class="member__img member__img--placeholder">
-            <i class="fas fa-shield-halved"></i>
+            <i class="fas fa-heart-pulse"></i>
           </div>
-          <h4 class="member__name">Abbey</h4>
+          <h4 class="member__name">Deniz</h4>
           <p class="member__role">Wellbeing Officer</p>
 
-          <a href="https://www.linkedin.com/in/abigailvr/" class="member__social" target="_blank" rel="noopener noreferrer" aria-label="Abbey's LinkedIn profile"><i class="fab fa-linkedin-in"></i></a>
+          <span class="member__social member__social--disabled" aria-label="LinkedIn coming soon"><i class="fab fa-linkedin-in"></i></span>
         </div>
         <div class="member">
           <div class="member__img member__img--placeholder">
-            <i class="fas fa-flag"></i>
+            <i class="fas fa-user-plus"></i>
           </div>
-          <h4 class="member__name">Charlie</h4>
+          <h4 class="member__name">Vacant</h4>
           <p class="member__role">CTF Officer</p>
 
-          <a href="https://www.linkedin.com/in/charlie-burrows-07108a336" class="member__social" target="_blank" rel="noopener noreferrer" aria-label="Charlie's LinkedIn profile"><i class="fab fa-linkedin-in"></i></a>
+          <span class="member__social member__social--disabled" aria-label="CTF Officer position currently vacant"><i class="fas fa-user-plus"></i></span>
         </div>
         <div class="member">
           <div class="member__img member__img--placeholder">
-            <i class="fas fa-chalkboard-user"></i>
+            <i class="fas fa-graduation-cap"></i>
           </div>
-          <h4 class="member__name">Ethan</h4>
+          <h4 class="member__name">Ashley</h4>
           <p class="member__role">CTF Mentor</p>
 
-          <a href="https://www.linkedin.com/in/ethan-bauer-842124368/" class="member__social" target="_blank" rel="noopener noreferrer" aria-label="Ethan's LinkedIn profile"><i class="fab fa-linkedin-in"></i></a>
+          <span class="member__social member__social--disabled" aria-label="LinkedIn coming soon"><i class="fab fa-linkedin-in"></i></span>
         </div>
       </div>
       <div class="committee-cta">

--- a/js/main.js
+++ b/js/main.js
@@ -155,6 +155,11 @@ document.addEventListener('DOMContentLoaded', () => {
         link.setAttribute('aria-label', (member.name || member.fullName) + "'s LinkedIn profile");
         appendIcon(link, 'fab fa-linkedin-in');
         card.appendChild(link);
+      } else if (member.vacant) {
+        const vacant = el('span', 'member__social member__social--disabled');
+        vacant.setAttribute('aria-label', member.role + ' position currently vacant');
+        appendIcon(vacant, 'fas fa-user-plus');
+        card.appendChild(vacant);
       } else {
         const disabled = el('span', 'member__social member__social--disabled');
         disabled.setAttribute('aria-label', 'LinkedIn coming soon');
@@ -217,6 +222,84 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  const chartPalette = [
+    '#c8102e',
+    '#00e4ff',
+    '#f4c95d',
+    '#34d399',
+    '#8b5cf6',
+    '#f97316',
+    '#f43f5e',
+    '#14b8a6',
+    '#e879f9',
+    '#a3e635',
+    '#38bdf8',
+    '#94a3b8'
+  ];
+
+  function totalCount(items) {
+    return (items || []).reduce((sum, item) => sum + Number(item.count || 0), 0);
+  }
+
+  function percentLabel(count, total) {
+    if (!total) return '0%';
+    return Math.round((Number(count || 0) / total) * 100) + '%';
+  }
+
+  function itemColor(item, index) {
+    return item.color || chartPalette[index % chartPalette.length];
+  }
+
+  function chartGradient(items, total) {
+    if (!items?.length || !total) return 'conic-gradient(rgba(255,255,255,.08) 0 100%)';
+    let cursor = 0;
+    const stops = items.map((item, index) => {
+      const start = cursor;
+      cursor += (Number(item.count || 0) / total) * 100;
+      return itemColor(item, index) + ' ' + start.toFixed(2) + '% ' + cursor.toFixed(2) + '%';
+    });
+    return 'conic-gradient(' + stops.join(', ') + ')';
+  }
+
+  function renderBreakdownCard(config) {
+    const items = config.items || [];
+    const total = totalCount(items);
+    const article = el('article', 'p2p-breakdown-card');
+    const visual = el('div', 'p2p-breakdown-card__visual');
+
+    const chart = el('div', 'p2p-breakdown-chart');
+    chart.style.background = chartGradient(items, total);
+    chart.setAttribute('role', 'img');
+    chart.setAttribute('aria-label', config.title + ' pie chart for ' + total + ' challenges');
+    const centre = el('div', 'p2p-breakdown-chart__centre');
+    centre.appendChild(el('strong', null, String(total)));
+    centre.appendChild(el('span', null, 'challenges'));
+    chart.appendChild(centre);
+    visual.appendChild(chart);
+    article.appendChild(visual);
+
+    const body = el('div', 'p2p-breakdown-card__body');
+    body.appendChild(el('span', 'p2p-breakdown-card__eyebrow', config.eyebrow));
+    body.appendChild(el('h3', 'p2p-breakdown-card__title', config.title));
+    body.appendChild(el('p', 'p2p-breakdown-card__text', config.text));
+
+    const list = el('ul', 'p2p-breakdown-list');
+    items.forEach((item, index) => {
+      const row = el('li');
+      const label = el('span', 'p2p-breakdown-list__label');
+      const swatch = el('span', 'p2p-breakdown-list__swatch');
+      swatch.style.background = itemColor(item, index);
+      label.appendChild(swatch);
+      label.appendChild(document.createTextNode(item.title));
+      row.appendChild(label);
+      row.appendChild(el('span', 'p2p-breakdown-list__value', item.count + ' / ' + percentLabel(item.count, total)));
+      list.appendChild(row);
+    });
+    body.appendChild(list);
+    article.appendChild(body);
+    return article;
+  }
+
   function renderP2PCategories() {
     const categories = siteContent.p2p?.categories;
     const container = document.querySelector('[data-p2p-categories]');
@@ -240,6 +323,67 @@ document.addEventListener('DOMContentLoaded', () => {
       card.appendChild(el('p', 'card__text', category.text));
       container.appendChild(card);
     });
+  }
+
+  function renderP2PPulse() {
+    const pulse = siteContent.p2p?.pulse;
+    const container = document.querySelector('[data-p2p-pulse]');
+    if (!container || !pulse?.stats?.length) return;
+
+    const section = container.closest('section');
+    const tag = section?.querySelector('[data-p2p-pulse-tag]');
+    const title = section?.querySelector('[data-p2p-pulse-title]');
+    const subtitle = section?.querySelector('[data-p2p-pulse-subtitle]');
+    if (tag && pulse.tag) tag.textContent = pulse.tag;
+    if (title && pulse.title) title.textContent = pulse.title;
+    if (subtitle && pulse.subtitle) subtitle.textContent = pulse.subtitle;
+
+    clear(container);
+    pulse.stats.forEach(stat => {
+      const tile = el('article', 'p2p-pulse__tile');
+      if (stat.key) tile.dataset.pulseKey = stat.key;
+      const pending = stat.value === '—' || stat.value == null || stat.value === '';
+      if (pending) tile.classList.add('is-pending');
+      tile.appendChild(el('span', 'p2p-pulse__label', stat.label || ''));
+      const valueEl = el('strong', 'p2p-pulse__value', pending ? '—' : String(stat.value));
+      if (!pending) {
+        const match = String(stat.value).match(/^([\d,]+)(.*)$/);
+        if (match) {
+          valueEl.dataset.pulseCount = match[1].replace(/,/g, '');
+          if (match[2]) valueEl.dataset.pulseSuffix = match[2];
+        }
+      }
+      tile.appendChild(valueEl);
+      if (stat.suffix) tile.appendChild(el('span', 'p2p-pulse__suffix', stat.suffix));
+      container.appendChild(tile);
+    });
+  }
+
+  function renderP2PChallengeBreakdown() {
+    const p2p = siteContent.p2p;
+    const container = document.querySelector('[data-p2p-breakdown]');
+    if (!container || !p2p?.categories?.length || !p2p?.difficultyBreakdown?.length) return;
+
+    const total = totalCount(p2p.categories);
+    const section = container.closest('section');
+    const tag = section?.querySelector('.section__tag');
+    const subtitle = section?.querySelector('.section__subtitle');
+    if (tag) tag.textContent = '2026 Spread';
+    if (subtitle) subtitle.textContent = total + ' challenges across categories and difficulties.';
+
+    clear(container);
+    container.appendChild(renderBreakdownCard({
+      eyebrow: 'Categories',
+      title: 'Challenge Categories',
+      text: 'The final category mix for Pwn2Play: Core Incursion 2026.',
+      items: p2p.categories
+    }));
+    container.appendChild(renderBreakdownCard({
+      eyebrow: 'Difficulty',
+      title: 'Challenge Difficulties',
+      text: 'Difficulty labels from the final 2026 challenge set.',
+      items: p2p.difficultyBreakdown
+    }));
   }
 
   function rankLabel(rank) {
@@ -779,7 +923,9 @@ document.addEventListener('DOMContentLoaded', () => {
     renderP2PKeyInfo();
     renderP2PActionLinks();
     renderP2PCalendarLinks();
+    renderP2PPulse();
     renderP2PCategories();
+    renderP2PChallengeBreakdown();
     renderP2PPrizes();
     renderP2PScoreboards();
     renderP2PLastUpdated();
@@ -1438,6 +1584,39 @@ document.addEventListener('DOMContentLoaded', () => {
       { threshold: 0.5 }
     );
     statNumbers.forEach(el => countObserver.observe(el));
+  }
+
+  /* ---------- Pulse counter animation ---------- */
+  const pulseValues = document.querySelectorAll('.p2p-pulse__value[data-pulse-count]');
+  const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+  if (pulseValues.length && !reduceMotion && 'IntersectionObserver' in window) {
+    const pulseObserver = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (!entry.isIntersecting) return;
+          const node = entry.target;
+          const target = parseInt(node.dataset.pulseCount, 10);
+          const suffix = node.dataset.pulseSuffix || '';
+          if (Number.isNaN(target)) {
+            pulseObserver.unobserve(node);
+            return;
+          }
+          const duration = 1400;
+          const start = performance.now();
+          node.textContent = '0' + suffix;
+          function step(now) {
+            const progress = Math.min((now - start) / duration, 1);
+            const eased = 1 - Math.pow(1 - progress, 3);
+            node.textContent = Math.round(target * eased) + suffix;
+            if (progress < 1) requestAnimationFrame(step);
+          }
+          requestAnimationFrame(step);
+          pulseObserver.unobserve(node);
+        });
+      },
+      { threshold: 0.4 }
+    );
+    pulseValues.forEach(node => pulseObserver.observe(node));
   }
 
   /* ---------- Circuit board trace background ---------- */

--- a/scripts/check-render.js
+++ b/scripts/check-render.js
@@ -24,7 +24,9 @@ const pages = [
   {
     file: 'P2P.html',
     checks: () => ({
+      pulse: document.querySelectorAll('[data-p2p-pulse] .p2p-pulse__tile').length,
       categories: document.querySelectorAll('[data-p2p-categories] .p2p-cat-card').length,
+      breakdown: document.querySelectorAll('[data-p2p-breakdown] .p2p-breakdown-card').length,
       prizes: document.querySelectorAll('[data-p2p-prizes] .prize-podium__place').length,
       rules: document.querySelectorAll('[data-p2p-rules] .rule').length,
       scoreboards: document.querySelectorAll('[data-p2p-scoreboards] .scoreboard-track').length,
@@ -32,6 +34,8 @@ const pages = [
     }),
     lightChecks: [
       '.p2p-event-tile--headline .hero-countdown__unit',
+      '.p2p-pulse__tile',
+      '.p2p-breakdown-card',
       '.prize-podium__place',
       '.scoreboard-track',
       '.sponsor-recruitment',

--- a/scripts/check-site.js
+++ b/scripts/check-site.js
@@ -50,7 +50,21 @@ function checkSiteContent() {
   const categories = data.p2p?.categories || [];
   const categoryTotal = categories.reduce((sum, category) => sum + Number(category.count || 0), 0);
   if (categories.length !== 12) fail(`Expected 12 Pwn2Play categories, found ${categories.length}`);
-  if (categoryTotal !== 50) fail(`Expected 50 Pwn2Play challenges, found ${categoryTotal}`);
+  if (categoryTotal <= 0) fail('Pwn2Play category challenge total must be greater than 0');
+
+  const difficulties = data.p2p?.difficultyBreakdown || [];
+  const difficultyTotal = difficulties.reduce((sum, difficulty) => sum + Number(difficulty.count || 0), 0);
+  if (!difficulties.length) fail('Missing Pwn2Play difficulty breakdown');
+  if (difficultyTotal !== categoryTotal) {
+    fail(`Pwn2Play category total (${categoryTotal}) does not match difficulty total (${difficultyTotal})`);
+  }
+
+  const pulseStats = data.p2p?.pulse?.stats || [];
+  if (pulseStats.length !== 4) fail(`Expected 4 Pwn2Play pulse stats, found ${pulseStats.length}`);
+  const pulseKeys = pulseStats.map(stat => stat.key);
+  ['signups', 'teams', 'challenges', 'flags'].forEach(key => {
+    if (!pulseKeys.includes(key)) fail(`Missing Pwn2Play pulse stat: ${key}`);
+  });
 
   const prizes = data.p2p?.prizes;
   if (!prizes?.placements || prizes.placements.length !== 3) fail('Expected 3 Pwn2Play prize placements');


### PR DESCRIPTION
- New Live Pulse section on P2P.html with signups/teams/challenges/flags tiles, count-up animation, pending state for live flag total
- Refresh challenge totals to 55 (Full-Pwn 4, Easy 25, Hard 8, drop Unspecified) across data, donut breakdown, and static fallbacks
- 26/27 committee swap: Josh chair, Nikita secretary, Amara treasurer, Deniz wellbeing, CTF Officer vacant, Ashley CTF mentor
- Light-mode coverage for pulse tiles, updated meta/og/twitter copy with new scale, README + check scripts updated for new fields