### PR TITLE
Editorial type system + P2P poster hero

### DIFF
--- a/P2P.html
+++ b/P2P.html
@@ -107,93 +107,49 @@
   </nav>
 
   <!-- Hero -->
-  <section id="p2p-hero" class="hero p2p-event-hero">
-    <div class="hero__content p2p-event-hero__content">
-      <div class="p2p-event-grid p2p-event-grid--hero">
-        <div class="p2p-event-primary">
-          <article class="p2p-event-tile p2p-event-tile--headline">
-            <span class="p2p-event-tile__eyebrow">Core Incursion</span>
-            <h1 class="hero__title">Pwn<span class="hero__accent">2</span>Play CTF</h1>
+  <section id="p2p-hero" class="hero p2p-poster-hero">
+    <div class="p2p-poster">
+      <span class="p2p-poster__eyebrow">DMU Hackers presents &middot; 2026</span>
 
-            <!-- Countdown -->
-            <div class="hero-countdown" id="countdown">
-              <p class="hero-countdown__until">Core Incursion begins in</p>
-              <div class="hero-countdown__timer">
-                <div class="hero-countdown__unit">
-                  <span class="hero-countdown__num" id="cdDays">--</span>
-                  <span class="hero-countdown__label">Days</span>
-                </div>
-                <span class="hero-countdown__sep"></span>
-                <div class="hero-countdown__unit">
-                  <span class="hero-countdown__num" id="cdHours">--</span>
-                  <span class="hero-countdown__label">Hours</span>
-                </div>
-                <span class="hero-countdown__sep"></span>
-                <div class="hero-countdown__unit">
-                  <span class="hero-countdown__num" id="cdMins">--</span>
-                  <span class="hero-countdown__label">Mins</span>
-                </div>
-                <span class="hero-countdown__sep"></span>
-                <div class="hero-countdown__unit">
-                  <span class="hero-countdown__num" id="cdSecs">--</span>
-                  <span class="hero-countdown__label">Secs</span>
-                </div>
-              </div>
-            </div>
-          </article>
+      <h1 class="p2p-poster__wordmark">
+        <span class="p2p-poster__word">Pwn</span><span class="p2p-poster__digit">2</span><span class="p2p-poster__word">Play</span>
+      </h1>
 
-          <div id="register" class="p2p-luma p2p-luma--hero">
-            <iframe
-              src="https://luma.com/embed/event/evt-9baefgwD4wSfcBc/simple"
-              width="600"
-              height="450"
-              frameborder="0"
-              allow="fullscreen; payment"
-              aria-hidden="false"
-              tabindex="0"
-              title="Register for Pwn2Play: Core Incursion on Luma"></iframe>
+      <p class="p2p-poster__subhead">Core Incursion &mdash; a hybrid student CTF.</p>
+
+      <div class="hero-countdown p2p-poster__countdown" id="countdown">
+        <div class="hero-countdown__timer">
+          <div class="hero-countdown__unit">
+            <span class="hero-countdown__num" id="cdDays">--</span>
+            <span class="hero-countdown__label">Days</span>
+          </div>
+          <span class="hero-countdown__sep"></span>
+          <div class="hero-countdown__unit">
+            <span class="hero-countdown__num" id="cdHours">--</span>
+            <span class="hero-countdown__label">Hours</span>
+          </div>
+          <span class="hero-countdown__sep"></span>
+          <div class="hero-countdown__unit">
+            <span class="hero-countdown__num" id="cdMins">--</span>
+            <span class="hero-countdown__label">Mins</span>
+          </div>
+          <span class="hero-countdown__sep"></span>
+          <div class="hero-countdown__unit">
+            <span class="hero-countdown__num" id="cdSecs">--</span>
+            <span class="hero-countdown__label">Secs</span>
           </div>
         </div>
+      </div>
 
-        <div class="p2p-event-details">
-          <article class="p2p-event-tile p2p-event-tile--brief">
-            <span class="p2p-event-tile__eyebrow">Pwn2Play: Core Incursion</span>
-            <h3>Hybrid student CTF for teams of up to 6</h3>
-            <p>A rigorous Jeopardy-style competition built to validate practical skills and connect emerging cyber talent with industry sponsors.</p>
-          </article>
+      <dl class="p2p-poster__billing">
+        <div><dt>When</dt><dd>Sat 30 May 2026 &middot; 09:00 &ndash; 18:00</dd></div>
+        <div><dt>Where</dt><dd>DMU Gateway House, Floor 5 &middot; Online</dd></div>
+        <div><dt>Format</dt><dd>Teams of up to 6 &middot; Jeopardy CTF</dd></div>
+      </dl>
 
-          <article class="p2p-event-tile p2p-event-tile--stat p2p-event-tile--date">
-            <i class="fas fa-calendar-alt"></i>
-            <span>Date &amp; Time</span>
-            <strong>Saturday 30th May 2026</strong>
-            <p>09:00 &ndash; 18:00</p>
-          </article>
-
-          <article class="p2p-event-tile p2p-event-tile--stat p2p-event-tile--location">
-            <i class="fas fa-map-marker-alt"></i>
-            <span>Location</span>
-            <strong>Virtual &amp; DMU Campus</strong>
-            <p>In-person competitors will be based at Gateway House, Floor 5.</p>
-          </article>
-
-          <article class="p2p-event-tile p2p-event-tile--stat p2p-event-tile--format">
-            <i class="fas fa-users"></i>
-            <span>Format</span>
-            <strong>Up to 6 members</strong>
-            <p>Compete online or in person.</p>
-          </article>
-        </div>
-
-        <article class="p2p-event-tile p2p-event-tile--actions">
-          <span class="p2p-event-tile__eyebrow">Plan the day</span>
-          <div class="p2p-event-actions">
-            <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Pwn2Play%3A+Core+Incursion+-+DMU+Hackers+CTF&dates=20260530T080000Z/20260530T170000Z&details=DMU+Hackers%27+flagship+Capture+The+Flag+competition.+Register%3A+https%3A%2F%2Fluma.com%2Fembed%2Fevent%2Fevt-9baefgwD4wSfcBc%2Fsimple&location=Gateway+House+Floor+5%2C+De+Montfort+University%2C+The+Gateway%2C+Leicester+LE1+9BH" class="btn btn--ghost btn--sm" target="_blank" rel="noopener noreferrer"><i class="fab fa-google"></i> Google Calendar</a>
-            <a href="data/p2p-core-incursion.ics" class="btn btn--ghost btn--sm" download><i class="fas fa-calendar-plus"></i> .ics</a>
-            <a href="https://pwn2play.biterra.co" class="btn btn--ghost btn--sm" target="_blank" rel="noopener noreferrer"><i class="fas fa-flag"></i> Biterra</a>
-            <a href="map.html" class="btn btn--ghost btn--sm"><i class="fas fa-map-location-dot"></i> Map</a>
-            <a href="https://discord.gg/Vvrk4kK" class="btn btn--ghost btn--sm" target="_blank" rel="noopener noreferrer"><i class="fab fa-discord"></i> Discord</a>
-          </div>
-        </article>
+      <div class="p2p-poster__actions">
+        <a href="register.html" class="btn btn--primary"><i class="fas fa-ticket"></i> Register</a>
+        <a href="https://discord.gg/Vvrk4kK" class="btn btn--ghost" target="_blank" rel="noopener noreferrer"><i class="fab fa-discord"></i> Discord</a>
       </div>
     </div>
   </section>

--- a/css/P2P.css
+++ b/css/P2P.css
@@ -26,7 +26,7 @@
 }
 
 .hero-countdown__until {
-  font-family: var(--font-display);
+  font-family: var(--font);
   font-size: .7rem;
   font-weight: 600;
   letter-spacing: .18em;
@@ -71,7 +71,7 @@
 }
 
 .hero-countdown__label {
-  font-family: var(--font-display);
+  font-family: var(--font);
   font-size: .6rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -193,386 +193,193 @@
   }
 }
 
-/* ---------- P2P Hero Event Wall ---------- */
-.p2p-event-hero {
+/* ---------- P2P Poster Hero ---------- */
+.p2p-poster-hero {
   min-height: 100svh;
   align-items: center;
-  padding: calc(var(--nav-h) + clamp(18px, 3vh, 30px)) 24px clamp(48px, 6vh, 72px);
+  justify-content: center;
+  padding: calc(var(--nav-h) + clamp(24px, 4vh, 56px)) 24px clamp(56px, 8vh, 96px);
+  text-align: center;
 }
 
-.p2p-event-hero__content {
-  width: min(1180px, 100%);
-  max-width: 1180px;
-}
-
-.p2p-event-hero .hero-countdown {
-  margin-bottom: 0;
-}
-
-.p2p-event-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.62fr) minmax(340px, .88fr);
-  gap: 14px;
-  max-width: 1180px;
-  margin: 0 auto;
-  align-items: stretch;
-}
-
-.p2p-event-grid--hero {
-  width: 100%;
-}
-
-.p2p-event-primary,
-.p2p-event-details {
-  display: grid;
-  gap: 14px;
-  min-height: 0;
-  min-width: 0;
-}
-
-.p2p-event-primary {
-  grid-template-rows: auto auto;
-}
-
-.p2p-event-details {
-  grid-template-columns: 1fr;
-  grid-template-rows: repeat(4, minmax(0, 1fr));
-  gap: 10px;
-  align-content: stretch;
-  align-self: stretch;
-}
-
-.p2p-event-tile {
-  position: relative;
-  overflow: hidden;
-  border-radius: var(--radius);
-  border: 1px solid rgba(255,255,255,.06);
-  background:
-    linear-gradient(180deg, rgba(255,255,255,.045), rgba(255,255,255,.012)),
-    rgba(20, 20, 24, .7);
-  padding: 22px;
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.035);
-  transition: border-color .35s, transform .35s cubic-bezier(.4,0,.2,1), box-shadow .35s;
-}
-.p2p-event-tile::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 18px;
-  right: 18px;
-  height: 2px;
-  background: linear-gradient(90deg, transparent, var(--accent), transparent);
-  opacity: .42;
-  pointer-events: none;
-}
-.p2p-event-tile > * {
-  position: relative;
-  z-index: 1;
-}
-.p2p-event-tile:hover {
-  border-color: rgba(200,16,46,.2);
-  box-shadow:
-    inset 0 1px 0 rgba(255,255,255,.045),
-    0 12px 34px rgba(0,0,0,.24),
-    0 0 24px rgba(200,16,46,.035);
-  transform: translateY(-2px);
-}
-
-.p2p-event-tile--headline {
+.p2p-poster {
+  width: min(1120px, 100%);
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  min-height: 156px;
-  padding: clamp(16px, 2vw, 22px);
-  text-align: left;
+  align-items: center;
+  gap: clamp(20px, 3vh, 36px);
 }
 
-.p2p-event-tile--headline .hero__title {
-  margin-bottom: 16px;
-  font-size: clamp(2.4rem, 4.4vw, 4.2rem);
-  text-align: left;
-}
-
-.p2p-event-tile--headline .p2p-event-tile__eyebrow {
-  margin-bottom: 6px;
-}
-
-.p2p-event-tile--headline .hero-countdown {
-  text-align: left;
-}
-
-.p2p-event-tile--headline .hero-countdown__until {
-  display: block;
-  width: fit-content;
-  margin-bottom: 10px;
-  padding: 0;
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-  color: var(--text-muted);
-  font-family: var(--font-display);
-  font-size: .66rem;
-  letter-spacing: .18em;
-  text-align: left;
-  text-shadow: none;
-}
-
-.p2p-event-tile--headline .hero-countdown__until::before {
-  display: none;
-}
-
-.p2p-event-tile--headline .hero-countdown__timer {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 7px;
-  width: 100%;
-  margin-top: 0;
-  padding: 0;
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-  box-shadow: none;
-}
-
-.p2p-event-tile--headline .hero-countdown__sep {
-  display: none;
-}
-
-.p2p-event-tile--headline .hero-countdown__unit {
+.p2p-poster__eyebrow {
   position: relative;
-  overflow: hidden;
-  min-width: 0;
-  padding: 10px 8px 9px;
-  border: 1px solid rgba(255,255,255,.08);
-  border-radius: 12px;
-  background:
-    linear-gradient(180deg, rgba(255,255,255,.055), rgba(255,255,255,.015)),
-    rgba(32,32,36,.9);
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  font-family: var(--font);
+  font-size: .72rem;
+  font-weight: 600;
+  letter-spacing: .24em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.p2p-poster__eyebrow::before,
+.p2p-poster__eyebrow::after {
+  content: '';
+  width: clamp(28px, 6vw, 64px);
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--text-muted), transparent);
+}
+
+.p2p-poster__wordmark {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(3.2rem, 14vw, 11rem);
+  line-height: .9;
+  letter-spacing: -.025em;
+  color: var(--text);
+  font-optical-sizing: auto;
+  font-variation-settings: 'opsz' 144, 'SOFT' 30;
+  white-space: nowrap;
+}
+.p2p-poster__word,
+.p2p-poster__digit {
+  display: inline-block;
+}
+.p2p-poster__digit {
+  color: var(--accent);
+  font-style: italic;
+  font-variation-settings: 'opsz' 144, 'SOFT' 100, 'WONK' 1;
+  transform: translateY(-.02em);
+  padding: 0 .02em;
+}
+
+.p2p-poster__subhead {
+  margin: 0;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(1.05rem, 1.8vw, 1.5rem);
+  letter-spacing: .005em;
+  color: var(--text-muted);
+  font-optical-sizing: auto;
+  font-variation-settings: 'opsz' 24;
+  max-width: 38ch;
+}
+
+.p2p-poster__countdown {
+  margin: 0;
+}
+.p2p-poster__countdown .hero-countdown__until {
+  display: none;
+}
+.p2p-poster__countdown .hero-countdown__timer {
+  gap: 10px;
+}
+.p2p-poster__countdown .hero-countdown__unit {
+  min-width: 64px;
+  padding: 12px 10px 10px;
+  border-radius: 10px;
+  background: rgba(15, 17, 24, .55);
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
-  box-shadow:
-    inset 0 1px 0 rgba(255,255,255,.035),
-    0 8px 18px rgba(0,0,0,.16);
+  border: 1px solid rgba(255,255,255,.08);
+  box-shadow: none;
 }
-
-.p2p-event-tile--headline .hero-countdown__unit::before {
-  display: none;
+.p2p-poster__countdown .hero-countdown__unit:hover {
+  border-color: rgba(200,16,46,.22);
+  box-shadow: none;
 }
-
-.p2p-event-tile--headline .hero-countdown__unit::after {
-  display: none;
-}
-
-.p2p-event-tile--headline .hero-countdown__num {
-  position: relative;
-  z-index: 1;
-  color: #fff;
+.p2p-poster__countdown .hero-countdown__num {
   font-family: var(--font-mono);
-  font-size: clamp(1.25rem, 2.2vw, 1.8rem);
+  font-size: clamp(1.3rem, 2.2vw, 1.7rem);
   font-variant-numeric: tabular-nums;
   letter-spacing: .02em;
-  line-height: 1;
-  text-shadow: none;
+  color: var(--text);
 }
-
-.p2p-event-tile--headline .hero-countdown__label {
-  position: relative;
-  z-index: 1;
+.p2p-poster__countdown .hero-countdown__label {
   margin-top: 6px;
-  color: rgba(255,255,255,.72);
-  font-family: var(--font-display);
-  font-size: .52rem;
-  letter-spacing: .14em;
+  font-size: .55rem;
+}
+.p2p-poster__countdown .hero-countdown__sep {
+  padding-bottom: 12px;
 }
 
-.p2p-event-tile--headline .hero-countdown__unit:hover {
-  border-color: rgba(255,255,255,.14);
-  box-shadow:
-    inset 0 1px 0 rgba(255,255,255,.04),
-    0 8px 18px rgba(0,0,0,.16);
-}
-
-.p2p-event-tile--headline .hero-countdown__timer--message {
-  display: flex;
+.p2p-poster__billing {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 18px;
+  row-gap: 8px;
+  margin: 0;
+  padding: 18px 24px;
+  border-top: 1px solid rgba(255,255,255,.08);
+  border-bottom: 1px solid rgba(255,255,255,.08);
+  text-align: left;
+  max-width: 560px;
   width: 100%;
 }
-
-.p2p-event-tile--brief {
-  grid-column: 1 / -1;
+.p2p-poster__billing > div {
+  display: contents;
 }
-
-.p2p-event-tile--stat {
-  grid-column: 1 / -1;
-  min-height: 118px;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
+.p2p-poster__billing dt {
+  font-family: var(--font);
+  font-size: .68rem;
+  font-weight: 600;
+  letter-spacing: .2em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding-top: .12em;
 }
-
-.p2p-event-tile--location {
-  grid-column: 1 / -1;
-}
-
-.p2p-event-tile--actions {
-  grid-column: 1 / -1;
-  min-height: 76px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-}
-
-.p2p-event-details .p2p-event-tile {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  min-height: 0;
-  padding: 14px 18px;
-}
-
-.p2p-event-details .p2p-event-tile > i {
-  margin-bottom: 8px;
-  font-size: 1rem;
-}
-
-.p2p-event-details .p2p-event-tile__eyebrow {
-  margin-bottom: 6px;
-  font-size: .66rem;
-}
-
-.p2p-event-details .p2p-event-tile > span:not(.p2p-event-tile__eyebrow) {
-  margin-bottom: 5px;
-  font-size: .64rem;
-}
-
-.p2p-event-details .p2p-event-tile h3,
-.p2p-event-details .p2p-event-tile strong {
-  font-size: 1rem;
-  line-height: 1.2;
-}
-
-.p2p-event-details .p2p-event-tile h3 {
-  margin-bottom: 6px;
-}
-
-.p2p-event-details .p2p-event-tile > p {
-  font-size: .78rem;
+.p2p-poster__billing dd {
+  margin: 0;
+  font-family: var(--font);
+  font-size: .98rem;
+  font-weight: 500;
+  color: var(--text);
   line-height: 1.35;
 }
 
-.p2p-event-details .p2p-event-tile--stat > p {
-  margin-top: 6px;
-}
-
-.p2p-event-tile > i {
-  color: var(--accent);
-  font-size: 1.1rem;
-  margin-bottom: 16px;
-}
-
-.p2p-event-tile > span:not(.p2p-event-tile__eyebrow) {
-  display: block;
-  margin-bottom: 8px;
-  color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: .7rem;
-  letter-spacing: .08em;
-  text-transform: uppercase;
-}
-
-.p2p-event-tile strong,
-.p2p-event-tile h3 {
-  display: block;
-  color: var(--text);
-  font-family: var(--font-display);
-  font-size: 1.08rem;
-  line-height: 1.25;
-}
-
-.p2p-event-tile h3 {
-  margin-bottom: 10px;
-  font-size: 1.2rem;
-}
-
-.p2p-event-tile > p {
-  color: var(--text-muted);
-  font-size: .9rem;
-  line-height: 1.6;
-}
-
-.p2p-event-tile--stat > p {
-  margin-top: 8px;
-  font-size: .82rem;
-  line-height: 1.45;
-}
-
-.p2p-event-tile__header {
-  margin-bottom: 18px;
-}
-
-.p2p-event-tile__eyebrow {
-  display: inline-block;
-  margin-bottom: 10px;
-  color: var(--accent);
-  font-family: var(--font-display);
-  font-size: .72rem;
-  font-weight: 700;
-  letter-spacing: .14em;
-  text-transform: uppercase;
-}
-
-.p2p-luma {
+.p2p-poster__actions {
   display: flex;
-  aspect-ratio: 16 / 9;
-  min-height: 0;
-  min-width: 0;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  box-shadow: none;
-  scroll-margin-top: calc(var(--nav-h) + 24px);
-}
-
-.p2p-luma iframe {
-  display: block;
-  width: 100%;
-  min-height: 0;
-  height: 100%;
-  border: 1px solid #bfcbda88;
-  border-radius: 10px;
-  background: #fff;
-}
-
-.p2p-event-actions {
-  display: flex;
+  gap: 12px;
   flex-wrap: wrap;
-  align-items: center;
-  gap: 10px;
-  margin-top: 18px;
+  justify-content: center;
 }
 
-.p2p-event-tile--actions .p2p-event-actions {
-  justify-content: flex-end;
-  margin-left: auto;
-  margin-top: 0;
+@media (max-width: 640px) {
+  .p2p-poster {
+    align-items: flex-start;
+    text-align: left;
+    gap: 24px;
+  }
+  .p2p-poster__eyebrow::before {
+    display: none;
+  }
+  .p2p-poster__wordmark {
+    white-space: normal;
+    letter-spacing: -.03em;
+  }
+  .p2p-poster__billing {
+    padding: 16px 0;
+    column-gap: 12px;
+  }
+  .p2p-poster__countdown .hero-countdown__timer {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 6px;
+  }
+  .p2p-poster__countdown .hero-countdown__sep {
+    display: none;
+  }
+  .p2p-poster__countdown .hero-countdown__unit {
+    min-width: 0;
+  }
+  .p2p-poster__actions {
+    justify-content: flex-start;
+  }
 }
 
-.p2p-event-tile--actions .p2p-event-tile__eyebrow {
-  margin-bottom: 0;
-}
-
-.p2p-event-actions .btn {
-  align-items: center;
-  white-space: nowrap;
-}
-
-.p2p-event-actions .btn i {
-  margin: 0;
-  line-height: 1;
-}
 
 /* ---------- Challenge Category Cards ---------- */
 .p2p-cat-cards {
@@ -1315,21 +1122,6 @@
 }
 
 @media (max-width: 1024px) {
-  .p2p-event-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .p2p-event-details {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-template-rows: repeat(2, minmax(118px, 1fr));
-  }
-
-  .p2p-event-tile--brief,
-  .p2p-event-tile--location,
-  .p2p-event-tile--stat {
-    grid-column: auto;
-  }
-
   .p2p-sponsor-grid--prizes {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -1340,51 +1132,8 @@
     min-height: auto;
     padding: 78px 0;
   }
-
-  .p2p-event-hero {
+  .p2p-poster-hero {
     padding: calc(var(--nav-h) + 22px) 18px 54px;
-  }
-
-  .p2p-event-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .p2p-event-details {
-    grid-template-columns: 1fr;
-    grid-template-rows: repeat(4, minmax(118px, 1fr));
-  }
-
-  .p2p-event-tile--headline,
-  .p2p-luma,
-  .p2p-event-tile--brief,
-  .p2p-event-tile--stat,
-  .p2p-event-tile--location,
-  .p2p-event-tile--format,
-  .p2p-event-tile--actions {
-    grid-column: 1 / -1;
-  }
-
-  .p2p-event-tile--headline .hero-countdown__timer {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .p2p-event-tile {
-    padding: 20px;
-  }
-
-  .p2p-event-tile--actions {
-    display: block;
-  }
-
-  .p2p-event-tile--actions .p2p-event-actions {
-    justify-content: flex-start;
-    margin-top: 14px;
-  }
-
-  .p2p-luma,
-  .p2p-luma iframe {
-    aspect-ratio: auto;
-    min-height: 520px;
   }
   .p2p-sponsor-band {
     padding: 22px;
@@ -1402,16 +1151,7 @@
   }
 }
 
-@media (min-width: 769px) and (max-width: 960px) {
-  .p2p-event-tile--headline .hero-countdown__timer {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-}
-
 @media (max-width: 480px) {
-  .p2p-event-tile {
-    padding: 18px;
-  }
   .p2p-sponsor-band {
     padding: 18px;
   }

--- a/css/main.css
+++ b/css/main.css
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 /* ---------- Custom Properties ---------- */
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=JetBrains+Mono:wght@300..700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,800;1,9..144,400;1,9..144,500;1,9..144,600&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@300..700&display=swap');
 
 :root {
   --bg:          #0b0c10;
@@ -20,8 +20,8 @@
   --radius:      12px;
   --nav-h:       64px;
   --max-w:       1120px;
-  --font:        'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --font-display: var(--font);
+  --font:        'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-display: 'Fraunces', Georgia, 'Times New Roman', serif;
   --font-mono:   'JetBrains Mono', monospace;
 
   --noise-sample-0: #127012;
@@ -237,7 +237,7 @@ ul  { list-style: none; }
 
 .hero__tag {
   display: inline-block;
-  font-family: var(--font-display);
+  font-family: var(--font);
   font-size: .78rem;
   font-weight: 600;
   letter-spacing: .18em;
@@ -254,10 +254,11 @@ ul  { list-style: none; }
   font-family: var(--font-display);
   font-size: clamp(3rem, 10vw, 5.5rem);
   font-weight: 700;
-  letter-spacing: .01em;
+  letter-spacing: -.015em;
   color: var(--text);
   line-height: 1.05;
   margin-bottom: 28px;
+  font-optical-sizing: auto;
 }
 
 .hero__accent {
@@ -615,7 +616,7 @@ ul  { list-style: none; }
 
 .section__tag {
   display: inline-block;
-  font-family: var(--font-display);
+  font-family: var(--font);
   font-size: .72rem;
   font-weight: 600;
   letter-spacing: .16em;
@@ -628,8 +629,9 @@ ul  { list-style: none; }
   font-family: var(--font-display);
   font-size: clamp(1.9rem, 4.5vw, 2.8rem);
   font-weight: 700;
-  letter-spacing: -.005em;
+  letter-spacing: -.015em;
   color: var(--text);
+  font-optical-sizing: auto;
 }
 
 .section__subtitle {

--- a/css/theme-toggle.css
+++ b/css/theme-toggle.css
@@ -371,50 +371,39 @@ html.light .podium-nav__btn:hover {
   background: rgba(200,16,46,.04);
 }
 
-/* P2P event wall */
-html.light .p2p-event-tile {
+/* P2P poster hero */
+html.light .p2p-poster__eyebrow {
+  color: var(--text-muted);
+}
+html.light .p2p-poster__eyebrow::before,
+html.light .p2p-poster__eyebrow::after {
+  background: linear-gradient(90deg, transparent, rgba(0,0,0,.25), transparent);
+}
+html.light .p2p-poster__wordmark {
+  color: var(--text);
+}
+html.light .p2p-poster__digit {
+  color: #a00d24;
+}
+html.light .p2p-poster__subhead {
+  color: var(--text-muted);
+}
+html.light .p2p-poster__billing {
+  border-top-color: rgba(0,0,0,.1);
+  border-bottom-color: rgba(0,0,0,.1);
+}
+html.light .p2p-poster__billing dt {
+  color: var(--text-muted);
+}
+html.light .p2p-poster__billing dd {
+  color: var(--text);
+}
+html.light .p2p-poster__countdown .hero-countdown__unit {
   background: rgba(255,255,255,.8);
-  border-color: rgba(0,0,0,.06);
-  box-shadow: inset 0 1px 0 rgba(0,0,0,.02);
-}
-html.light .p2p-event-tile > span:not(.p2p-event-tile__eyebrow),
-html.light .p2p-event-tile > p {
-  color: var(--text-muted);
-}
-html.light .p2p-event-tile strong,
-html.light .p2p-event-tile h3,
-html.light .p2p-event-tile .hero__title {
-  color: var(--text);
-}
-html.light .p2p-event-tile--headline .hero-countdown__unit {
-  background:
-    linear-gradient(180deg, rgba(255,255,255,.92), rgba(255,255,255,.74)),
-    rgba(255,255,255,.88);
-  border-color: rgba(0,0,0,.08);
-  box-shadow:
-    inset 0 1px 0 rgba(255,255,255,.82),
-    0 8px 18px rgba(0,0,0,.07);
-}
-html.light .p2p-event-tile--headline .hero-countdown__num {
-  color: var(--text);
-}
-html.light .p2p-event-tile--headline .hero-countdown__label {
-  color: var(--text-muted);
-}
-html.light .p2p-event-tile--headline .hero-countdown__unit:hover {
-  border-color: rgba(200,16,46,.18);
-  box-shadow:
-    inset 0 1px 0 rgba(255,255,255,.88),
-    0 10px 22px rgba(0,0,0,.08),
-    0 0 18px rgba(200,16,46,.035);
-}
-html.light .p2p-event-tile--headline .hero-countdown__timer--message {
-  background: rgba(255,255,255,.84);
   border-color: rgba(0,0,0,.08);
 }
-html.light .p2p-luma iframe {
-  border-color: rgba(0,0,0,.1);
-  box-shadow: 0 14px 34px rgba(0,0,0,.08);
+html.light .p2p-poster__countdown .hero-countdown__num {
+  color: var(--text);
 }
 
 /* P2P live event pulse */

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
 
       <p class="hero__sub">Cyber security, CTF competitions, and hands-on hacking.<br>Every Thursday at 18:00. All skill levels welcome.</p>
       <div class="hero__actions">
-        <a href="P2P.html#register" class="btn btn--primary"><i class="fas fa-ticket"></i> Register for Pwn2Play</a>
+        <a href="register.html" class="btn btn--primary"><i class="fas fa-ticket"></i> Register for Pwn2Play</a>
         <a href="P2P.html" class="btn btn--ghost"><i class="fas fa-flag"></i> Event Details</a>
         <a href="https://discord.gg/Vvrk4kK" class="btn btn--ghost" target="_blank" rel="noopener noreferrer"><i class="fab fa-discord"></i> Join Discord</a>
       </div>
@@ -352,7 +352,7 @@
             <div class="stat"><span class="stat__number" data-count="12">0</span><span class="stat__label">Categories</span></div>
             <div class="stat"><span class="stat__number" data-count="2">0</span><span class="stat__label">Events</span></div>
           </div>
-          <a href="P2P.html#register" class="btn btn--primary"><i class="fas fa-ticket"></i> Register for Pwn2Play</a>
+          <a href="register.html" class="btn btn--primary"><i class="fas fa-ticket"></i> Register for Pwn2Play</a>
           <a href="P2P.html" class="btn btn--ghost">Event Details &rarr;</a>
         </div>
       </div>

--- a/js/main.js
+++ b/js/main.js
@@ -583,11 +583,6 @@ document.addEventListener('DOMContentLoaded', () => {
       links.forEach(link => container.appendChild(renderActionLink(link)));
     });
 
-    const heroActions = document.querySelector('.p2p-event-actions');
-    if (heroActions) {
-      clear(heroActions);
-      links.forEach(link => heroActions.appendChild(renderActionLink(link)));
-    }
   }
 
   function renderP2PCalendarLinks() {
@@ -632,30 +627,6 @@ document.addEventListener('DOMContentLoaded', () => {
       summary.appendChild(el('strong', null, formatDisplayDate(event.start)));
       summary.appendChild(document.createTextNode(', ' + formatClock(event.start) + '-' + formatClock(event.end) + '. Add it to your calendar so you do not miss it.'));
     }
-  }
-
-  function updateP2PEventDetails() {
-    const p2p = siteContent.p2p;
-    if (!p2p?.event) return;
-
-    const dateTile = document.querySelector('.p2p-event-tile--date');
-    if (dateTile) {
-      const strong = dateTile.querySelector('strong');
-      const text = dateTile.querySelector('p');
-      if (strong) strong.textContent = formatDisplayDate(p2p.event.start);
-      if (text) text.textContent = formatClock(p2p.event.start) + ' - ' + formatClock(p2p.event.end);
-    }
-
-    const locationTile = document.querySelector('.p2p-event-tile--location');
-    if (locationTile && p2p.venues?.[0]) {
-      const strong = locationTile.querySelector('strong');
-      const text = locationTile.querySelector('p');
-      if (strong) strong.textContent = 'Virtual & DMU Campus';
-      if (text) text.textContent = 'In-person competitors will be based at ' + p2p.venues[0].addressLines[0] + '.';
-    }
-
-    const luma = document.querySelector('.p2p-luma iframe');
-    if (luma && p2p.links?.luma) luma.src = p2p.links.luma;
   }
 
   function renderP2PScoreboards() {
@@ -918,7 +889,6 @@ document.addEventListener('DOMContentLoaded', () => {
   function renderMaintainableContent() {
     renderCurrentCommittee();
     renderCommitteeTimeline();
-    updateP2PEventDetails();
     updateP2PGlobalLinks();
     renderP2PKeyInfo();
     renderP2PActionLinks();

--- a/map.html
+++ b/map.html
@@ -194,7 +194,7 @@
       </div>
       <div style="display:flex;justify-content:center;gap:12px;flex-wrap:wrap;margin-top:32px;">
         <a href="P2P.html" class="btn btn--primary"><i class="fas fa-arrow-left"></i> Back to Pwn2Play</a>
-        <a href="P2P.html#register" class="btn btn--ghost"><i class="fas fa-user-plus"></i> Register</a>
+        <a href="register.html" class="btn btn--ghost"><i class="fas fa-user-plus"></i> Register</a>
       </div>
     </div>
   </section>

--- a/scripts/check-render.js
+++ b/scripts/check-render.js
@@ -33,7 +33,7 @@ const pages = [
       podium: document.querySelectorAll('#podiumContainer .podium__place').length
     }),
     lightChecks: [
-      '.p2p-event-tile--headline .hero-countdown__unit',
+      '.p2p-poster__countdown .hero-countdown__unit',
       '.p2p-pulse__tile',
       '.p2p-breakdown-card',
       '.prize-podium__place',


### PR DESCRIPTION
## Summary
- Swap the type system to **Fraunces** (variable serif, opsz axis 9&ndash;144) for display and **Inter** for body; drop Outfit from the Google Fonts import. Tracked-out eyebrows (`.section__tag`, `.hero__tag`, hero-countdown labels) move to Inter so the small-caps style still reads cleanly under a serif display.
- Tighten letter-spacing on `.hero__title` / `.section__title` now that a serif sits in their place; wire `font-optical-sizing: auto` so Fraunces scales from labels up to poster headlines.
- Rebuild the P2P hero as an **event poster**: oversized `PWN2PLAY` wordmark (red italic "2" with `WONK 1`), italic subhead, compact countdown, movie-poster billing block (When / Where / Format), Register + Discord CTAs. Removes the 7-tile event wall, the Luma iframe, and the stacked action strip. Net diff on the hero alone: &minus;380 lines of CSS.
- Repoint homepage and `map.html` Register links to `register.html` (the in-page `#register` Luma anchor is gone). Prune now-dead JS (`.p2p-event-actions` writer, `updateP2PEventDetails`, `.p2p-luma iframe` handle) and the matching light-mode tile overrides; add light-mode shading for the new `.p2p-poster-*` classes. Update `scripts/check-render.js` to inspect the new countdown selector.

## Why
The PR #5 cleanup gave us a calmer site but the all-Outfit type system felt flat and the P2P hero still read like a product page. Fraunces + Inter give the site editorial character, and turning the P2P hero into a poster matches the user's framing of "advert for Pwn2Play, not a registration form".

## Test plan
- [ ] All pages load in dark + light mode with Fraunces (display) + Inter (body); no Outfit/Chakra Petch fallback flashing.
- [ ] P2P hero: massive PWN2PLAY wordmark with red italic "2", eyebrow rules, italic subhead, countdown ticking, billing block reads as a poster credit strip.
- [ ] Register button → `register.html`. Discord button opens Discord in a new tab. No Luma iframe anywhere on the page.
- [ ] Resize 1440px &rarr; 360px: wordmark scales fluidly, billing block stacks gracefully.
- [ ] DevTools &rarr; Network: only Fraunces + Inter + JetBrains Mono fonts requested.
- [ ] DevTools &rarr; Console: no errors. Theme toggle works in both directions.
- [ ] `prefers-reduced-motion: reduce` &mdash; no new motion introduced.