### PR TITLE
Graphical schedule tiles + P2P hero/section cleanup + collapsible rules/sponsors

### DIFF
--- a/P2P.html
+++ b/P2P.html
@@ -93,7 +93,6 @@
         <li><a href="#event-pulse" class="nav__link" data-section="event-pulse">Pulse</a></li>
         <li><a href="#categories" class="nav__link" data-section="categories">Categories</a></li>
         <li><a href="#challenge-spread" class="nav__link" data-section="challenge-spread">Breakdown</a></li>
-        <li><a href="#prizes" class="nav__link" data-section="prizes">Prizes</a></li>
         <li><a href="#rules" class="nav__link" data-section="rules">Rules</a></li>
         <li><a href="#sponsors" class="nav__link" data-section="sponsors">Sponsors</a></li>
       </ul>
@@ -141,12 +140,6 @@
         </div>
       </div>
 
-      <dl class="p2p-poster__billing">
-        <div><dt>When</dt><dd>Sat 30 May 2026 &middot; 09:00 &ndash; 18:00</dd></div>
-        <div><dt>Where</dt><dd>DMU Gateway House, Floor 5 &middot; Online</dd></div>
-        <div><dt>Format</dt><dd>Teams of up to 6 &middot; Jeopardy CTF</dd></div>
-      </dl>
-
       <div class="p2p-poster__actions">
         <a href="register.html" class="btn btn--primary"><i class="fas fa-ticket"></i> Register</a>
         <a href="https://discord.gg/Vvrk4kK" class="btn btn--ghost" target="_blank" rel="noopener noreferrer"><i class="fab fa-discord"></i> Discord</a>
@@ -165,11 +158,6 @@
           <span class="section__tag">Exclusive Platform Partner</span>
           <h2 class="section__title">Pwn<span class="hero__accent">2</span>Play runs on Biterra</h2>
           <p>Biterra is the gamified learning platform that hosts every Pwn2Play challenge, scoreboard, and team. Built by a DMU Hackers alumnus, it&rsquo;s the permanent home for our flagship CTF &mdash; and provides our event merchandise. Wherever Pwn2Play goes, Biterra is the platform underneath it.</p>
-          <div class="p2p-platform-feature__meta">
-            <span><i class="fas fa-server" aria-hidden="true"></i> Hosting Platform</span>
-            <span><i class="fas fa-gift" aria-hidden="true"></i> Event Merchandise</span>
-            <span><i class="fas fa-link" aria-hidden="true"></i> pwn2play.biterra.co</span>
-          </div>
           <a href="https://pwn2play.biterra.co" class="btn btn--primary" target="_blank" rel="noopener noreferrer">
             <i class="fas fa-arrow-up-right-from-square"></i> Open Pwn2Play on Biterra
           </a>
@@ -424,57 +412,6 @@
       </div>
       <div class="calendar-actions" style="margin-top: 32px;" data-p2p-action-links>
         <a href="map.html" class="btn btn--ghost"><i class="fas fa-map-location-dot"></i> View Campus Map</a>
-      </div>
-    </div>
-  </section>
-
-  <!-- Prizes -->
-  <section id="prizes" class="section">
-    <div class="container">
-      <div class="section__header">
-        <span class="section__tag">Rewards</span>
-        <h2 class="section__title">In-Person Prizes</h2>
-        <p class="section__subtitle">Challenge Coins and TryHackMe Premium vouchers are reserved for the in-person podium.</p>
-      </div>
-      <div class="prizes-showcase" data-p2p-prizes>
-        <div class="prizes-showcase__intro">
-          <span class="prizes-showcase__kicker">In-person rewards</span>
-          <p>In-person podium teams receive formal recognition, a P2P Challenge Coin and TryHackMe Premium time for four team members.</p>
-        </div>
-
-        <div class="prize-podium" aria-label="Pwn2Play in-person prize rewards by placement">
-          <article class="prize-podium__place prize-podium__place--first">
-            <span class="prize-podium__rank">1st</span>
-            <h3>First Place</h3>
-            <ul class="prize-podium__rewards">
-              <li><i class="fas fa-certificate"></i> Faculty-signed Certificate</li>
-              <li><i class="fas fa-coins"></i> P2P Challenge Coin</li>
-              <li><i class="fas fa-user-shield"></i> 4x 6-month TryHackMe Premium vouchers</li>
-            </ul>
-          </article>
-
-          <article class="prize-podium__place prize-podium__place--second">
-            <span class="prize-podium__rank">2nd</span>
-            <h3>Second Place</h3>
-            <ul class="prize-podium__rewards">
-              <li><i class="fas fa-certificate"></i> Faculty-signed Certificate</li>
-              <li><i class="fas fa-coins"></i> P2P Challenge Coin</li>
-              <li><i class="fas fa-user-shield"></i> 4x 3-month TryHackMe Premium vouchers</li>
-            </ul>
-          </article>
-
-          <article class="prize-podium__place prize-podium__place--third">
-            <span class="prize-podium__rank">3rd</span>
-            <h3>Third Place</h3>
-            <ul class="prize-podium__rewards">
-              <li><i class="fas fa-certificate"></i> Faculty-signed Certificate</li>
-              <li><i class="fas fa-coins"></i> P2P Challenge Coin</li>
-              <li><i class="fas fa-user-shield"></i> 4x 1-month TryHackMe Premium vouchers</li>
-            </ul>
-          </article>
-        </div>
-
-        <p class="prize-note"><i class="fas fa-award"></i> Online and in-person winners receive a Certificate of Achievement signed by DMU Faculty for LinkedIn and professional portfolios. Challenge Coins and TryHackMe vouchers are awarded to in-person podium teams.</p>
       </div>
     </div>
   </section>
@@ -840,7 +777,6 @@
             <a href="index.html">Home</a>
             <a href="#p2p-hero">Pwn2Play</a>
             <a href="#key-info">Key Info</a>
-              <a href="#prizes">Prizes</a>
           </nav>
         </div>
         <div class="footer__col">

--- a/css/P2P.css
+++ b/css/P2P.css
@@ -384,31 +384,12 @@
 .p2p-platform-feature .section__title {
   font-size: clamp(1.6rem, 3vw, 2.2rem);
 }
-.p2p-platform-feature__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 18px;
-  margin-bottom: 28px;
-  font-family: var(--font-mono);
-  font-size: .8rem;
-  color: var(--text-muted);
-}
-.p2p-platform-feature__meta span {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-.p2p-platform-feature__meta i {
-  color: var(--accent);
-  opacity: .9;
-}
-
 @media (max-width: 768px) {
   .p2p-platform-feature .p2p-split { flex-direction: column; gap: 28px; }
   .p2p-platform-feature .p2p-split__img { flex: none; max-width: 220px; margin: 0 auto; }
   .p2p-platform-feature .p2p-split__content { text-align: center; }
   .p2p-platform-feature .p2p-split__content .section__title { text-align: center; }
-  .p2p-platform-feature__meta { justify-content: center; }
+  .p2p-platform-feature .p2p-split__content p { margin-left: auto; margin-right: auto; }
 }
 
 @media (max-width: 640px) {
@@ -1768,5 +1749,141 @@
   .afterparty__detail {
     padding: 10px 16px;
     font-size: .82rem;
+  }
+}
+
+/* ---------- Rules: "Show more rules" expand tab ---------- */
+.rules-stack__more {
+  display: block;
+  margin-top: 8px;
+}
+.rules-stack__toggle {
+  list-style: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 22px;
+  margin-left: clamp(36px, 6vw, 88px);
+  border: 1px solid rgba(255,255,255,.14);
+  background: rgba(255,255,255,.02);
+  font-family: var(--font);
+  font-size: .72rem;
+  font-weight: 600;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  transition: border-color .2s ease, color .2s ease, background .2s ease;
+}
+.rules-stack__toggle::-webkit-details-marker { display: none; }
+.rules-stack__toggle::marker { content: ''; }
+.rules-stack__toggle:hover {
+  border-color: rgba(255,255,255,.32);
+  color: var(--text);
+  background: rgba(255,255,255,.04);
+}
+.rules-stack__toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.rules-stack__toggle-chevron {
+  color: var(--accent);
+  font-size: .75rem;
+  transition: transform .3s ease;
+}
+.rules-stack__more[open] .rules-stack__toggle-chevron {
+  transform: rotate(180deg);
+}
+.rules-stack__toggle-label--hide { display: none; }
+.rules-stack__more[open] .rules-stack__toggle-label--show { display: none; }
+.rules-stack__more[open] .rules-stack__toggle-label--hide { display: inline; }
+.rules-stack__more-list {
+  margin-top: clamp(20px, 3vh, 32px);
+  display: flex;
+  flex-direction: column;
+  gap: inherit;
+  animation: rules-fade-in .35s ease;
+}
+@keyframes rules-fade-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ---------- Sponsors: per-band card collapse ---------- */
+.p2p-sponsor-band__collapse {
+  display: block;
+}
+.p2p-sponsor-band__summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 18px 0;
+  border-bottom: 1px solid rgba(255,255,255,.06);
+  transition: border-color .25s ease;
+}
+.p2p-sponsor-band__summary::-webkit-details-marker { display: none; }
+.p2p-sponsor-band__summary::marker { content: ''; }
+.p2p-sponsor-band__summary:hover {
+  border-bottom-color: rgba(255,255,255,.18);
+}
+.p2p-sponsor-band__summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+.p2p-sponsor-band__collapse .p2p-sponsor-band__header {
+  margin: 0;
+  flex: 1;
+}
+.p2p-sponsor-band__indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+  padding: 8px 14px;
+  border: 1px solid rgba(255,255,255,.14);
+  background: rgba(255,255,255,.02);
+  font-family: var(--font);
+  font-size: .68rem;
+  font-weight: 600;
+  letter-spacing: .2em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  transition: border-color .2s ease, color .2s ease, background .2s ease;
+}
+.p2p-sponsor-band__summary:hover .p2p-sponsor-band__indicator {
+  border-color: rgba(255,255,255,.32);
+  color: var(--text);
+}
+.p2p-sponsor-band__indicator-chevron {
+  color: var(--accent);
+  font-size: .8rem;
+  transition: transform .3s ease;
+}
+.p2p-sponsor-band__collapse[open] .p2p-sponsor-band__indicator-chevron {
+  transform: rotate(180deg);
+}
+.p2p-sponsor-band__indicator-label--hide { display: none; }
+.p2p-sponsor-band__collapse[open] .p2p-sponsor-band__indicator-label--show { display: none; }
+.p2p-sponsor-band__collapse[open] .p2p-sponsor-band__indicator-label--hide { display: inline; }
+.p2p-sponsor-band__collapse .p2p-sponsor-grid {
+  margin-top: clamp(24px, 3vh, 36px);
+  animation: rules-fade-in .35s ease;
+}
+
+@media (max-width: 640px) {
+  .p2p-sponsor-band__summary {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 14px;
+  }
+  .p2p-sponsor-band__indicator {
+    align-self: flex-end;
+  }
+  .rules-stack__toggle {
+    margin-left: 0;
+    align-self: flex-start;
   }
 }

--- a/css/main.css
+++ b/css/main.css
@@ -485,41 +485,74 @@ ul  { list-style: none; }
   line-height: 1.7;
 }
 
-.hero__manifest {
+.hero__schedule {
+  display: inline-flex;
+  align-items: stretch;
+  justify-content: center;
+  gap: 0;
+  margin: 0 auto 32px;
+  padding: 18px 26px;
+  border: 1px solid rgba(255,255,255,.08);
+  background:
+    linear-gradient(180deg, rgba(255,255,255,.025), rgba(255,255,255,.005));
+  box-shadow:
+    0 1px 0 rgba(255,255,255,.04) inset,
+    0 18px 40px rgba(0,0,0,.32);
+  position: relative;
+}
+.hero__schedule::before,
+.hero__schedule::after {
+  content: '';
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border: 1px solid var(--accent);
+  opacity: .6;
+}
+.hero__schedule::before {
+  top: -1px; left: -1px;
+  border-right: 0;
+  border-bottom: 0;
+}
+.hero__schedule::after {
+  bottom: -1px; right: -1px;
+  border-left: 0;
+  border-top: 0;
+}
+.hero__schedule-item {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
-  width: max-content;
-  max-width: 100%;
-  margin: 0 auto 32px;
-  padding: 0;
-  font-family: var(--font-mono);
-  font-size: .95rem;
-  color: var(--text-muted);
-  user-select: text;
+  align-items: center;
+  gap: 6px;
+  padding: 0 28px;
+  min-width: 100px;
 }
-.hero__manifest-line {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-}
-.hero__manifest-line--out {
-  padding-left: 1.6ch;
-  color: var(--text-muted);
-  letter-spacing: .02em;
-  gap: 0;
-}
-.hero__manifest-prompt {
+.hero__schedule-icon {
   color: var(--accent);
+  font-size: 1.05rem;
+  opacity: .9;
+  margin-bottom: 2px;
+}
+.hero__schedule-value {
+  font-family: var(--font-display);
   font-weight: 700;
-}
-.hero__manifest-cmd {
+  font-size: clamp(1.7rem, 3.5vw, 2.1rem);
+  line-height: 1;
   color: var(--text);
+  letter-spacing: -.01em;
 }
-.hero__manifest-line--out strong {
-  color: var(--text);
+.hero__schedule-label {
+  font-family: var(--font);
+  font-size: .65rem;
   font-weight: 600;
+  letter-spacing: .22em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.hero__schedule-sep {
+  width: 1px;
+  background: linear-gradient(180deg, transparent, rgba(255,255,255,.12), transparent);
+  align-self: stretch;
 }
 
 .hero__actions {
@@ -1660,7 +1693,10 @@ a.card--link:hover .card__arrow {
   .hero-stat__number { font-size: 1.6rem; }
   .info-bar { flex-direction: column; align-items: center; }
   .hero__actions { flex-direction: column; align-items: center; }
-  .hero__manifest { font-size: .82rem; gap: 8px; }
+  .hero__schedule { padding: 14px 14px; }
+  .hero__schedule-item { padding: 0 14px; min-width: 78px; gap: 5px; }
+  .hero__schedule-value { font-size: 1.5rem; }
+  .hero__schedule-label { font-size: .58rem; letter-spacing: .18em; }
   .footer__top { grid-template-columns: 1fr; }
   .hero-term__body { max-height: 200px; }
 }

--- a/data/site-content.js
+++ b/data/site-content.js
@@ -35,7 +35,6 @@ window.DMU_SITE_CONTENT = {
         { text: "Pulse", href: "#event-pulse", section: "event-pulse" },
         { text: "Categories", href: "#categories", section: "categories" },
         { text: "Breakdown", href: "#challenge-spread", section: "challenge-spread" },
-        { text: "Prizes", href: "#prizes", section: "prizes" },
         { text: "Rules", href: "#rules", section: "rules" },
         { text: "Sponsors", href: "#sponsors", section: "sponsors" }
       ],
@@ -298,43 +297,6 @@ window.DMU_SITE_CONTENT = {
         { key: "teams", label: "Teams", value: "150+", suffix: "registered" },
         { key: "challenges", label: "Challenges", value: "55", suffix: "across 12 categories" },
         { key: "flags", label: "Flags Pwned", value: "—", suffix: "Live on 30 May" }
-      ]
-    },
-    prizes: {
-      tag: "Rewards",
-      title: "In-Person Prizes",
-      subtitle: "Challenge Coins and TryHackMe Premium vouchers are reserved for the in-person podium.",
-      kicker: "In-person rewards",
-      intro: "In-person podium teams receive formal recognition, a P2P Challenge Coin and TryHackMe Premium time for four team members.",
-      note: "Online and in-person winners receive a Certificate of Achievement signed by DMU Faculty for LinkedIn and professional portfolios. Challenge Coins and TryHackMe vouchers are awarded to in-person podium teams.",
-      placements: [
-        {
-          rank: 2,
-          title: "Second Place",
-          rewards: [
-            { icon: "fas fa-certificate", text: "Faculty-signed Certificate" },
-            { icon: "fas fa-coins", text: "P2P Challenge Coin" },
-            { icon: "fas fa-user-shield", text: "4x 3-month TryHackMe Premium vouchers" }
-          ]
-        },
-        {
-          rank: 1,
-          title: "First Place",
-          rewards: [
-            { icon: "fas fa-certificate", text: "Faculty-signed Certificate" },
-            { icon: "fas fa-coins", text: "P2P Challenge Coin" },
-            { icon: "fas fa-user-shield", text: "4x 6-month TryHackMe Premium vouchers" }
-          ]
-        },
-        {
-          rank: 3,
-          title: "Third Place",
-          rewards: [
-            { icon: "fas fa-certificate", text: "Faculty-signed Certificate" },
-            { icon: "fas fa-coins", text: "P2P Challenge Coin" },
-            { icon: "fas fa-user-shield", text: "4x 1-month TryHackMe Premium vouchers" }
-          ]
-        }
       ]
     },
     rules: [

--- a/index.html
+++ b/index.html
@@ -114,14 +114,24 @@
         <span class="hero-featured__arrow"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
       </a>
 
-      <div class="hero__manifest" aria-label="Next meetup">
-        <span class="hero__manifest-line">
-          <span class="hero__manifest-prompt" aria-hidden="true">$</span>
-          <span class="hero__manifest-cmd">grep ^THU sessions.txt</span>
-        </span>
-        <span class="hero__manifest-line hero__manifest-line--out">
-          <strong>THU</strong>&nbsp;&nbsp;<strong>18:00</strong>&nbsp;&nbsp;<strong>GH5.53</strong>
-        </span>
+      <div class="hero__schedule" aria-label="Next meetup">
+        <div class="hero__schedule-item">
+          <i class="fas fa-calendar-day hero__schedule-icon" aria-hidden="true"></i>
+          <span class="hero__schedule-value">THU</span>
+          <span class="hero__schedule-label">Day</span>
+        </div>
+        <span class="hero__schedule-sep" aria-hidden="true"></span>
+        <div class="hero__schedule-item">
+          <i class="fas fa-clock hero__schedule-icon" aria-hidden="true"></i>
+          <span class="hero__schedule-value">18:00</span>
+          <span class="hero__schedule-label">Time</span>
+        </div>
+        <span class="hero__schedule-sep" aria-hidden="true"></span>
+        <div class="hero__schedule-item">
+          <i class="fas fa-location-dot hero__schedule-icon" aria-hidden="true"></i>
+          <span class="hero__schedule-value">GH5.53</span>
+          <span class="hero__schedule-label">Room</span>
+        </div>
       </div>
       <div class="hero__socials hero__socials--compact">
         <a href="https://twitter.com/dmuhackers" target="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fab fa-x-twitter"></i></a>

--- a/js/main.js
+++ b/js/main.js
@@ -441,12 +441,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const container = document.querySelector('[data-p2p-rules]');
     if (!container || !rules?.length) return;
 
-    clear(container);
-    rules.forEach((rule, index) => {
+    function buildRuleRow(rule, index, isLast) {
       const row = el('div', 'rule' + (rule.critical ? ' rule--critical' : ''));
       const marker = el('div', 'rule__marker');
       marker.appendChild(el('span', 'rule__num', String(index + 1).padStart(2, '0')));
-      if (index !== rules.length - 1) marker.appendChild(el('div', 'rule__line'));
+      if (!isLast) marker.appendChild(el('div', 'rule__line'));
       row.appendChild(marker);
 
       const body = el('div', 'rule__body');
@@ -459,8 +458,38 @@ document.addEventListener('DOMContentLoaded', () => {
       (rule.items || []).forEach(text => list.appendChild(el('li', null, text)));
       body.appendChild(list);
       row.appendChild(body);
-      container.appendChild(row);
+      return row;
+    }
+
+    clear(container);
+    const totalRules = rules.length;
+    rules.slice(0, 1).forEach((rule, index) => {
+      container.appendChild(buildRuleRow(rule, index, totalRules === 1));
     });
+
+    const remaining = rules.slice(1);
+    if (!remaining.length) return;
+
+    const details = el('details', 'rules-stack__more');
+    const summary = el('summary', 'rules-stack__toggle');
+    const showLabel = el('span', 'rules-stack__toggle-label rules-stack__toggle-label--show');
+    showLabel.appendChild(document.createTextNode('Show ' + remaining.length + ' more rule' + (remaining.length === 1 ? '' : 's')));
+    const hideLabel = el('span', 'rules-stack__toggle-label rules-stack__toggle-label--hide');
+    hideLabel.appendChild(document.createTextNode('Hide additional rules'));
+    summary.appendChild(showLabel);
+    summary.appendChild(hideLabel);
+    const chevron = el('i', 'fas fa-chevron-down rules-stack__toggle-chevron');
+    chevron.setAttribute('aria-hidden', 'true');
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+
+    const more = el('div', 'rules-stack__more-list');
+    remaining.forEach((rule, idx) => {
+      const realIndex = idx + 1;
+      more.appendChild(buildRuleRow(rule, realIndex, realIndex === totalRules - 1));
+    });
+    details.appendChild(more);
+    container.appendChild(details);
   }
 
   function formatDisplayDate(dateString) {
@@ -702,14 +731,33 @@ document.addEventListener('DOMContentLoaded', () => {
       const items = sponsors.filter(sponsor => sponsor.groups?.includes(band.key));
       if (!items.length) return;
       const bandEl = el('div', 'p2p-sponsor-band p2p-sponsor-band--' + band.key);
+      const gridKey = band.key === 'challenge' ? 'challenge' : (band.key === 'platform' ? 'platform' : 'prizes');
+
+      const details = el('details', 'p2p-sponsor-band__collapse');
+      const summary = el('summary', 'p2p-sponsor-band__summary');
       const header = el('div', 'p2p-sponsor-band__header');
       header.appendChild(el('span', 'p2p-sponsor-band__eyebrow', band.title));
       header.appendChild(el('p', null, band.text));
-      bandEl.appendChild(header);
-      const gridKey = band.key === 'challenge' ? 'challenge' : (band.key === 'platform' ? 'platform' : 'prizes');
+      summary.appendChild(header);
+
+      const indicator = el('span', 'p2p-sponsor-band__indicator');
+      indicator.setAttribute('aria-hidden', 'true');
+      const showLabel = el('span', 'p2p-sponsor-band__indicator-label p2p-sponsor-band__indicator-label--show');
+      showLabel.appendChild(document.createTextNode('Show ' + items.length + ' sponsor' + (items.length === 1 ? '' : 's')));
+      const hideLabel = el('span', 'p2p-sponsor-band__indicator-label p2p-sponsor-band__indicator-label--hide');
+      hideLabel.appendChild(document.createTextNode('Hide sponsors'));
+      indicator.appendChild(showLabel);
+      indicator.appendChild(hideLabel);
+      const chevron = el('i', 'fas fa-chevron-down p2p-sponsor-band__indicator-chevron');
+      indicator.appendChild(chevron);
+      summary.appendChild(indicator);
+      details.appendChild(summary);
+
       const grid = el('div', 'p2p-sponsor-grid p2p-sponsor-grid--' + gridKey);
       items.forEach(sponsor => grid.appendChild(renderP2PSponsorCard(sponsor)));
-      bandEl.appendChild(grid);
+      details.appendChild(grid);
+
+      bandEl.appendChild(details);
       container.appendChild(bandEl);
     });
   }


### PR DESCRIPTION
## Summary

- **Home hero schedule** — replaced the plaintext grep manifest with a three-tile graphical composition: sharp container with accent corner brackets, Fraunces display values (THU / 18:00 / GH5.53), calendar/clock/pin icons on top of each tile, small uppercase labels (DAY / TIME / ROOM), thin vertical dividers between tiles. The Pwn2Play CTA above remains the only rounded element.
- **P2P hero cleanup** — removed the When/Where/Format definition list and the small "Powered by Biterra" badge. The dedicated Platform Partner section directly below the hero now carries the partnership weight on its own. Also dropped the Hosting Platform / Merchandise / pwn2play.biterra.co meta strip from the platform section so the headline + description + CTA do the talking.
- **Prizes section removed** — `<section id="prizes">`, its top + footer nav links, and the data block in `data/site-content.js` all gone. The dead `renderP2PPrizes()` function in `js/main.js` is left in place; it early-returns when the container is absent.
- **Collapsible Rules** — the long rules stack now renders only the first rule (`01 General Conduct`) up front, with a small "Show 9 more rules" expand tab below that reveals the rest. Chevron rotates 180° on open; toggle text swaps to "Hide additional rules". `renderP2PRules()` builds the new structure.
- **Collapsible Sponsors** — each sponsor band's header row (PRIZE PROVIDERS / CHALLENGE CREATORS) is now a clickable summary with a "Show N sponsors" indicator on the right. The card grid is what collapses; the band header description is always visible. `renderP2PSponsors()` builds the new structure.

## Why

The home hero schedule line had been through multiple iterations; the user explicitly wanted a more graphical, less plaintext treatment than the grep terminal manifest. Separately, the P2P page had several pieces of duplicated or unnecessary information competing with the dedicated Biterra platform section, and the Rules and Sponsors sections were dominating the scroll. Collapsing them by content (not by section) keeps the headers as navigational anchors while putting the bulk behind a single click.

## Notable details for review

- Both collapsibles use native `<details>`/`<summary>`. No JS toggle logic — just CSS for chevron rotation and Show/Hide span swap.
- The Rules expand button is left-aligned under the first rule's body, matching the existing rule margin (`clamp(36px, 6vw, 88px)`). On mobile (≤640px) it left-aligns to the section edge.
- Sponsor band summary is a full-width clickable row with hover/focus states; on mobile the indicator stacks below the header.
- `renderP2PPrizes()` is dead code (container removed). Left in to keep the diff scoped to the user's request — easy to delete in a future cleanup.

## Test plan

- [ ] Home hero renders three sharp tiles with icons, big values, and labels; corner brackets visible
- [ ] P2P hero shows eyebrow → wordmark → subhead → countdown → buttons only (no When/Where/Format, no Biterra badge)
- [ ] P2P Platform Partner section shows logo + headline + description + CTA only (no meta strip)
- [ ] P2P nav and footer nav have no "Prizes" link
- [ ] P2P `#prizes` section anchor does not exist
- [ ] Rules section shows only rule 01 by default with a "Show 9 more rules" tab; clicking expands the rest with chevron rotation
- [ ] Sponsors section shows each band header with a "Show N sponsors" indicator; clicking expands only that band's cards
- [ ] Mobile (375px): schedule tiles + collapse controls all stack/wrap cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)